### PR TITLE
Make serde an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ default = ["use_std"]
 # (for example). Currently, this isn't supported, and removing the 'use_std'
 # feature will prevent regex from compiling.
 use_std = []
+with-serde = ["serde", "serde_repr"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_repr = "0.1"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_repr = { version = "0.1", optional = true }
 
 [build-dependencies]
 cc = "1.0"
@@ -36,3 +37,6 @@ libc = "0.2"
 members = [
     "syscalls-gen",
 ]
+
+[package.metadata.docs.rs]
+features = ["use_std", "with-serde"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,12 +4,14 @@
 //! io:Error is not implemented for better no_std support.
 
 use core::result::Result;
-use serde::{Serialize, Deserialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// The 6 arguments of a syscall, raw untyped version.
 ///
 /// TODO: Use a helper function to convert to a structured Syscall+Args enum.
-#[derive(PartialEq, Debug, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SyscallArgs {
     pub arg0: u64,
     pub arg1: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,25 +8,18 @@ pub mod macros;
 mod nr;
 
 pub use args::{SyscallArgs, SyscallRet};
-pub use helper::{syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
+pub use helper::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};
 pub use nr::{SyscallNo, SyscallNo::*};
 
 /// do a syscall
 /// @nr: syscall number
 /// @args: packed arguments
 /// @return: Ok on success, Err when syscall failed (with errno)
-pub unsafe fn syscall(
-    nr: SyscallNo,
-    args: &SyscallArgs,
-) -> Result<i64, i64> {
+pub unsafe fn syscall(nr: SyscallNo, args: &SyscallArgs) -> Result<i64, i64> {
     crate::helper::syscall6(
-        nr,
-        args.arg0,
-        args.arg1,
-        args.arg2,
-        args.arg3,
-        args.arg4,
-        args.arg5,
+        nr, args.arg0, args.arg1, args.arg2, args.arg3, args.arg4, args.arg5,
     )
 }
 
@@ -100,10 +93,14 @@ mod tests {
                 let mut buffer1: [u8; 64] = unsafe { std::mem::zeroed() };
                 let mut buffer2: [u8; 64] = unsafe { std::mem::zeroed() };
 
-                let args = SyscallArgs::from(&[fd as u64, buffer1.as_mut_ptr() as _, 64, 16]);
-                let r1 = unsafe {
-                    syscall(SYS_pread64, &args)
-                }.expect("SYS_pread64 failed");
+                let args = SyscallArgs::from(&[
+                    fd as u64,
+                    buffer1.as_mut_ptr() as _,
+                    64,
+                    16,
+                ]);
+                let r1 = unsafe { syscall(SYS_pread64, &args) }
+                    .expect("SYS_pread64 failed");
 
                 let s1 = unsafe {
                     std::slice::from_raw_parts(

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -2,11 +2,11 @@
 
 pub use self::SyscallNo::*;
 use core::fmt;
-use serde_repr::{Serialize_repr, Deserialize_repr};
-
+#[cfg(feature = "serde_repr")]
+use serde_repr::{Deserialize_repr, Serialize_repr};
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-
-#[derive(PartialEq, Eq, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[derive(PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde_repr", derive(Serialize_repr, Deserialize_repr))]
 #[repr(i32)]
 pub enum SyscallNo {
     SYS_read = 0,
@@ -342,8 +342,10 @@ pub enum SyscallNo {
     SYS_pkey_alloc = 330,
     SYS_pkey_free = 331,
     SYS_statx = 332,
+    SYS_io_pgetevents = 333,
+    SYS_rseq = 334,
 }
-static SYSCALL_NAMES: [&str; 333] = [
+static SYSCALL_NAMES: [&str; 335] = [
     "read",
     "write",
     "open",
@@ -677,13 +679,15 @@ static SYSCALL_NAMES: [&str; 333] = [
     "pkey_alloc",
     "pkey_free",
     "statx",
+    "io_pgetevents",
+    "rseq",
 ];
 impl fmt::Debug for SyscallNo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", SYSCALL_NAMES[self.clone() as usize])
     }
 }
-static SYSCALL_IDS: [SyscallNo; 333] = [
+static SYSCALL_IDS: [SyscallNo; 335] = [
     SYS_read,
     SYS_write,
     SYS_open,
@@ -1017,6 +1021,8 @@ static SYSCALL_IDS: [SyscallNo; 333] = [
     SYS_pkey_alloc,
     SYS_pkey_free,
     SYS_statx,
+    SYS_io_pgetevents,
+    SYS_rseq,
 ];
 impl From<i32> for SyscallNo {
     fn from(item: i32) -> Self {

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -92,14 +92,16 @@ fn gen_syscall_nrs(dest: &Path) -> Result<()> {
     writeln!(f, "// AUTOMATICALLY GENERATED. DO NOT EDIT.\n")?;
     writeln!(f, "pub use self::SyscallNo::*;")?;
     writeln!(f, "use core::fmt;")?;
-    writeln!(f, "use serde_repr::{Serialize_repr, Deserialize_repr};")?;
+    writeln!(f, "#[cfg(feature = \"serde_repr\")]")?;
+    writeln!(f, "use serde_repr::{{Deserialize_repr, Serialize_repr}};")?;
 
     writeln!(
         f,
         "#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]"
     )?;
-    writeln!(f, "");
-    writeln!(f, "#[derive(PartialEq, Eq, Clone, Copy, Serialize_repr, Deserialize_repr)]")?;
+    writeln!(f, "#[derive(PartialEq, Eq, Clone, Copy)]")?;
+    writeln!(f, "#[cfg_attr(feature = \"serde_repr\", derive(Serialize_repr, Deserialize_repr))]")?;
+    writeln!(f, "#[repr(i32)]")?;
     writeln!(f, "pub enum SyscallNo {{")?;
 
     let syscalls = gen_syscalls()?;


### PR DESCRIPTION
Fixes #6.

The feature is called `with-serde` instead of `serde` because it can't be the same name as the `serde` dependency when we also need `serde_repr`.