### PR TITLE
Add SyscallNo::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,4 +137,12 @@ mod tests {
     fn test_name() {
         assert_eq!(SYS_write.name(), "write");
     }
+
+    #[test]
+    fn test_syscallno() {
+        assert_eq!(SyscallNo::from(2), SYS_open);
+        assert_eq!(SyscallNo::new(2), Some(SYS_open));
+        assert_eq!(SyscallNo::new(-1i32 as usize), None);
+        assert_eq!(SyscallNo::new(1024), None);
+    }
 }

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -704,9 +704,16 @@ static SYSCALL_NAMES: [&str; 345] = [
 ];
 
 impl SyscallNo {
+    /// Returns the name of the syscall.
     #[inline]
     pub fn name(&self) -> &'static str {
         SYSCALL_NAMES[*self as usize]
+    }
+
+    /// Constructs a `SyscallNo` from an ID. Returns `None` if the number falls
+    /// outside the bounds of possible enum values.
+    pub fn new(id: usize) -> Option<Self> {
+        SYSCALL_IDS.get(id).map(|x| *x)
     }
 }
 
@@ -1070,11 +1077,9 @@ static SYSCALL_IDS: [SyscallNo; 345] = [
     SYS_fspick,
 ];
 impl From<i32> for SyscallNo {
-    fn from(item: i32) -> Self {
-        if item as usize > SYSCALL_IDS.len() {
-            panic!("invalid syscall: {}", item)
-        } else {
-            SYSCALL_IDS[item as usize]
-        }
+    fn from(id: i32) -> Self {
+        Self::new(id as usize).unwrap_or_else(|| {
+            panic!("invalid syscall: {}", id)
+        })
     }
 }


### PR DESCRIPTION
This allows us to handle errors ourselves when constructing a SyscallNo from a raw ID.