### PR TITLE
syscall: drop readonly annotation from syscall0()

### DIFF
--- a/src/syscall/arm.rs
+++ b/src/syscall/arm.rs
@@ -28,7 +28,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         "svc 0",
         in("r7") n as usize,
         lateout("r0") ret,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     ret
 }

--- a/src/syscall/mips.rs
+++ b/src/syscall/mips.rs
@@ -59,7 +59,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         lateout("$15") _,
         lateout("$24") _,
         lateout("$25") _,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     if err == 0 {
         ret

--- a/src/syscall/mips64.rs
+++ b/src/syscall/mips64.rs
@@ -61,7 +61,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         lateout("$15") _,
         lateout("$24") _,
         lateout("$25") _,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     if err == 0 {
         ret

--- a/src/syscall/powerpc.rs
+++ b/src/syscall/powerpc.rs
@@ -44,7 +44,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         lateout("r11") _,
         lateout("r12") _,
         lateout("cr0") _,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     ret
 }

--- a/src/syscall/powerpc64.rs
+++ b/src/syscall/powerpc64.rs
@@ -44,7 +44,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         lateout("r11") _,
         lateout("r12") _,
         lateout("cr0") _,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     ret
 }

--- a/src/syscall/x86.rs
+++ b/src/syscall/x86.rs
@@ -27,7 +27,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
     asm!(
         "int $$0x80",
         inlateout("eax") n as usize => ret,
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     ret
 }

--- a/src/syscall/x86_64.rs
+++ b/src/syscall/x86_64.rs
@@ -29,7 +29,7 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
         inlateout("rax") n as usize => ret,
         out("rcx") _, // rcx is used to store old rip
         out("r11") _, // r11 is used to store old rflags
-        options(nostack, preserves_flags, readonly)
+        options(nostack, preserves_flags)
     );
     ret
 }


### PR DESCRIPTION
The syscall0() backends currently annotate the inline-asm as `readonly`, presumably because without argument there is little reason to assume the system call writes to memory. This patch drops this annotation under the assumption that there are scenarios where those calls will write to memory.

While we have not really found an obvious violation of this, there are definitely system calls that do affect mapped memory. For instance, the VDSO is updated on a wide range of system calls, fork(2) can write process identifiers to memory, sync(2) can cause mapped ring-buffers to clear, etc.

While it would probably be safe to argue that all those scenarios work with volatile memory and should thus be accessed with care, anyway, it is a fragile assumption to rely on. And we prefer being correct than slightly faster, so drop this annotation. If a particular system call does benefit from this, we can always add alternative entry-points. However, it is likely that all VDSO-optimizations would outperform any syscall-entry, so maybe the better alternative is to map the VDSO.