### PR TITLE
Implement SysnoMap, minor SysnoSet improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
           command: test
           args: --target ${{ matrix.target }}
 
+      - name: Run no-default test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target ${{ matrix.target }} --no-default-features
+
   test_nightly:
     name: Test Suite (Nightly)
     runs-on: ubuntu-latest
@@ -92,6 +99,13 @@ jobs:
           use-cross: true
           command: test
           args: --target ${{ matrix.target }}
+
+      - name: Run no-default test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target ${{ matrix.target }} --no-default-features
 
   rustfmt:
     name: Check format
@@ -147,4 +161,3 @@ jobs:
 
       - name: publish
         run: cargo publish --no-verify
-

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a low-level library for listing and invoking raw Linux system calls.
  - Provides a syscall enum for multiple architectures (see table below).
  - Provides methods for invoking raw syscalls.
  - Provides an `Errno` type for Rustic error handling.
+ - Provides O(1) array-backed `SysnoSet` and `SysnoMap<T>` types.
 
 ## Feature Flags
 
@@ -55,19 +56,19 @@ yet stabilized for all architectures][asm_experimental_arch].
 
 [asm_experimental_arch]: https://github.com/rust-lang/rust/issues/93335
 
-|     Arch    | Enum  | Invoke  | Stable Rust?      |
-|:-----------:|:-----:|:-------:|:-----------------:|
-|       `arm` |   ✅  |    ✅   | Yes ✅            |
-|   `aarch64` |   ✅  |    ✅   | Yes ✅            |
-|      `mips` |   ✅  |    ✅   | No ❌             |
-|    `mips64` |   ✅  |    ✅   | No ❌             |
-|   `powerpc` |   ✅  |    ✅   | No ❌             |
-| `powerpc64` |   ✅  |    ✅   | No ❌             |
-|     `s390x` |   ✅  |    ✅   | No ❌             |
-|     `sparc` |   ✅  |    ❌   | N/A               |
-|   `sparc64` |   ✅  |    ❌   | N/A               |
-|       `x86` |   ✅  |    ✅   | Yes ✅            |
-|    `x86_64` |   ✅  |    ✅   | Yes ✅            |
+|    Arch     | Enum | Invoke | Stable Rust? |
+|:-----------:|:----:|:------:|:------------:|
+|    `arm`    |  ✅   |   ✅    |    Yes ✅     |
+|  `aarch64`  |  ✅   |   ✅    |    Yes ✅     |
+|   `mips`    |  ✅   |   ✅    |     No ❌     |
+|  `mips64`   |  ✅   |   ✅    |     No ❌     |
+|  `powerpc`  |  ✅   |   ✅    |     No ❌     |
+| `powerpc64` |  ✅   |   ✅    |     No ❌     |
+|   `s390x`   |  ✅   |   ✅    |     No ❌     |
+|   `sparc`   |  ✅   |   ❌    |     N/A      |
+|  `sparc64`  |  ✅   |   ❌    |     N/A      |
+|    `x86`    |  ✅   |   ✅    |    Yes ✅     |
+|  `x86_64`   |  ✅   |   ✅    |    Yes ✅     |
 
 ## Updating the syscall list
 
@@ -77,4 +78,3 @@ Updates are pulled from the `.tbl` files in the Linux source tree.
     version. Only updated to the latest stable version (not release candidates).
  2. Run `cd syscalls-gen && cargo run`. This will regenerate the syscall tables
     in `src/arch/`.
-

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a low-level library for listing and invoking raw Linux system calls.
  - Provides a syscall enum for multiple architectures (see table below).
  - Provides methods for invoking raw syscalls.
  - Provides an `Errno` type for Rustic error handling.
- - Provides O(1) array-backed `SysnoSet` and `SysnoMap<T: Copy>` types.
+ - Provides O(1) array-backed `SysnoSet` and `SysnoMap` types.
 
 ## Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a low-level library for listing and invoking raw Linux system calls.
  - Provides a syscall enum for multiple architectures (see table below).
  - Provides methods for invoking raw syscalls.
  - Provides an `Errno` type for Rustic error handling.
- - Provides O(1) array-backed `SysnoSet` and `SysnoMap<T>` types.
+ - Provides O(1) array-backed `SysnoSet` and `SysnoMap<T: Copy>` types.
 
 ## Feature Flags
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 //! Provide helper functions/trait impls to pack/unpack
 //! [`SyscallArgs`].
 //!
-//! [`io:Error`] is not implemented for better `no_std` support.
+//! `io:Error` is not implemented for better `no_std` support.
 
 /// The 6 arguments of a syscall, raw untyped version.
 #[derive(PartialEq, Debug, Eq, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ mod syscall;
 pub use arch::*;
 pub use args::SyscallArgs;
 pub use errno::{Errno, ErrnoSentinel};
-pub use map::SysnoMap;
-pub use set::SysnoSet;
+pub use map::*;
+pub use set::*;
 
 pub mod raw {
     //! Exposes raw syscalls that simply return a `usize` instead of a `Result`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,14 @@ mod macros;
 mod arch;
 mod args;
 mod errno;
+mod map;
 mod set;
 mod syscall;
 
 pub use arch::*;
 pub use args::SyscallArgs;
 pub use errno::{Errno, ErrnoSentinel};
+pub use map::SysnoMap;
 pub use set::SysnoSet;
 
 pub mod raw {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,236 @@
+//! Enables the creation of a syscall hashmap.
+
+use super::Sysno;
+use crate::SysnoSet;
+use core::fmt;
+use std::fmt::Debug;
+use std::mem;
+
+/// A macro to simplify creation and optionally initializing a syscall map.
+///
+/// # Examples
+///
+/// Create a new map with a default value of `0` and initialize it with some values:
+/// ```
+/// # use syscalls::{syscall_map, Sysno, SysnoMap};
+/// let mut map = syscall_map!(
+///     0;
+///     Sysno::open => 0,
+///     Sysno::close => 42,
+/// );
+/// ```
+///
+/// Use custom copy-iable type:
+/// ```
+/// # use syscalls::{syscall_map, Sysno, SysnoMap};
+/// #[derive(Copy, Clone, Default)]
+/// struct Point { x: i32, y: i32 }
+/// let mut map = syscall_map!(Point::default());
+/// map.insert(Sysno::open, Point { x: 1, y: 2 });
+/// ```
+#[macro_export]
+macro_rules! syscall_map {
+    ($default:expr) => {
+        SysnoMap::new([$default; $crate::Sysno::table_size()])
+    };
+    ($default:expr; $($sysno:expr => $value:expr),* $(,)?) => {
+        {
+            let mut map = $crate::syscall_map!($default);
+            map.extend([$(($sysno, $value),)*]);
+            map
+        }
+    };
+}
+
+/// A map of syscalls.
+///
+/// This provides constant-time lookup of syscalls within a bitset.
+///
+/// # Examples
+///
+/// ```
+/// # use syscalls::{syscall_map, Sysno, SysnoMap};
+/// let mut syscalls = syscall_map!(
+///     0;
+///     Sysno::open => 0,
+///     Sysno::close => 42,
+/// );
+/// assert!(!syscalls.is_empty());
+/// assert_eq!(syscalls.remove(Sysno::open), Some(0));
+/// assert_eq!(syscalls.insert(Sysno::close, 4), Some(42));
+/// assert!(syscalls.contains_key(Sysno::close));
+/// assert_eq!(syscalls.get(Sysno::close), Some(&4));
+/// assert_eq!(syscalls.insert(Sysno::close, 11), Some(4));
+/// assert_eq!(syscalls.count(), 1);
+/// assert_eq!(syscalls.remove(Sysno::close), Some(11));
+/// assert!(syscalls.is_empty());
+/// ```
+#[derive(Clone, Eq, PartialEq)]
+pub struct SysnoMap<T> {
+    is_set: SysnoSet,
+    data: [T; Sysno::table_size()],
+}
+
+impl<T: Default> SysnoMap<T> {
+    /// Initialize an empty syscall map, must have hardcoded size `Sysno::table_size()`.
+    pub fn new(data: [T; Sysno::table_size()]) -> Self {
+        Self {
+            is_set: SysnoSet::empty(),
+            data,
+        }
+    }
+
+    /// Returns true if the map contains the given syscall.
+    pub const fn contains_key(&self, sysno: Sysno) -> bool {
+        self.is_set.contains(sysno)
+    }
+
+    /// Clears the map, removing all syscalls.
+    pub fn clear(&mut self) {
+        self.is_set.clear();
+        for elem in self.data.iter_mut() {
+            *elem = T::default();
+        }
+    }
+
+    /// Returns true if the map is empty. This is an O(n) operation as
+    /// it must iterate over the entire bitset.
+    pub fn is_empty(&self) -> bool {
+        self.is_set.is_empty()
+    }
+
+    /// Returns the number of syscalls in the map. This is an O(n) operation as
+    /// it must count the number of bits in the bitset.
+    pub fn count(&self) -> usize {
+        self.is_set.count()
+    }
+
+    /// Inserts the given syscall into the map. Returns true if the syscall was not already in the map.
+    pub fn insert(&mut self, sysno: Sysno, value: T) -> Option<T> {
+        let old = mem::replace(&mut self.data[sysno.id() as usize], value);
+        if self.is_set.insert(sysno) {
+            None
+        } else {
+            Some(old)
+        }
+    }
+
+    /// Removes the given syscall from the map. Returns true if the syscall was in the map.
+    pub fn remove(&mut self, sysno: Sysno) -> Option<T> {
+        if self.is_set.remove(sysno) {
+            Some(mem::take(&mut self.data[sysno.id() as usize]))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, sysno: Sysno) -> Option<&T> {
+        if self.is_set.contains(sysno) {
+            Some(&self.data[sysno.id() as usize])
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, sysno: Sysno) -> Option<&mut T> {
+        if self.is_set.contains(sysno) {
+            Some(&mut self.data[sysno.id() as usize])
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator that iterates over the syscalls contained in the map.
+    pub fn iter(&self) -> impl Iterator<Item = (Sysno, &T)> {
+        self.is_set
+            .iter()
+            .map(move |sysno| (sysno, &self.data[sysno.id() as usize]))
+    }
+}
+
+impl<T: Debug> Debug for SysnoMap<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_map()
+            .entries(
+                self.is_set
+                    .iter()
+                    .map(|sysno| (sysno, &self.data[sysno.id() as usize])),
+            )
+            .finish()
+    }
+}
+
+impl<T: Default> Extend<(Sysno, T)> for SysnoMap<T> {
+    fn extend<I: IntoIterator<Item = (Sysno, T)>>(&mut self, iter: I) {
+        for (sysno, value) in iter {
+            self.insert(sysno, value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        assert_eq!(syscall_map!(0_u8).count(), 0);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut map = syscall_map!(0_u8);
+        assert!(map.is_empty());
+        assert_eq!(map.insert(Sysno::openat, 42), None);
+        assert!(!map.is_empty());
+        assert_eq!(map.get(Sysno::openat), Some(&42));
+        map.remove(Sysno::openat);
+        assert!(map.is_empty());
+        assert_eq!(map.get(Sysno::openat), None);
+    }
+
+    #[test]
+    fn test_count() {
+        let mut map = syscall_map!(0_u8);
+        assert_eq!(map.count(), 0);
+        assert_eq!(map.insert(Sysno::openat, 42), None);
+        assert_eq!(map.count(), 1);
+        assert_eq!(map.insert(Sysno::first(), 4), None);
+        assert_eq!(map.count(), 2);
+        assert_eq!(map.insert(Sysno::last(), 5), None);
+        assert_eq!(map.count(), 3);
+    }
+
+    #[test]
+    fn test_insert_remove() {
+        let mut map = syscall_map!(0);
+        assert_eq!(map.insert(Sysno::openat, 42), None);
+        assert!(map.contains_key(Sysno::openat));
+        assert_eq!(map.count(), 1);
+
+        assert_eq!(map.insert(Sysno::openat, 4), Some(42));
+        assert!(map.contains_key(Sysno::openat));
+        assert_eq!(map.count(), 1);
+
+        assert_eq!(map.remove(Sysno::openat), Some(4));
+        assert!(!map.contains_key(Sysno::openat));
+        assert_eq!(map.count(), 0);
+
+        assert_eq!(map.remove(Sysno::openat), None);
+    }
+
+    #[test]
+    fn test_debug() {
+        let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);
+        assert_eq!(format!("{:?}", map), "{read: 42, openat: 10}");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_iter() {
+        let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);
+        assert_eq!(map.iter().collect::<Vec<_>>().len(), 2);
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,9 +2,7 @@
 
 use super::Sysno;
 use crate::SysnoSet;
-use core::fmt;
-use std::fmt::Debug;
-use std::mem;
+use core::{fmt, mem};
 
 /// A macro to simplify creation and optionally initializing a syscall map.
 ///
@@ -205,7 +203,7 @@ const fn data_idx(sysno: Sysno) -> usize {
     (sysno.id() as usize) - (Sysno::first().id() as usize)
 }
 
-impl<T: Debug> Debug for SysnoMap<T> {
+impl<T: fmt::Debug> fmt::Debug for SysnoMap<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
             .entries(
@@ -277,6 +275,7 @@ mod tests {
         assert_eq!(map.remove(Sysno::openat), None);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_debug() {
         let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);

--- a/src/map.rs
+++ b/src/map.rs
@@ -190,6 +190,13 @@ impl<T: Default> SysnoMap<T> {
             .iter()
             .map(move |sysno| (sysno, &self.data[sysno.id() as usize]))
     }
+
+    /// Returns an iterator that iterates over all enabled values contained in the map.
+    pub fn values(&self) -> impl Iterator<Item = &T> {
+        self.is_set
+            .iter()
+            .map(move |sysno| &self.data[sysno.id() as usize])
+    }
 }
 
 impl<T: Debug> Debug for SysnoMap<T> {
@@ -243,6 +250,7 @@ mod tests {
         assert_eq!(map.count(), 2);
         assert_eq!(map.insert(Sysno::last(), 5), None);
         assert_eq!(map.count(), 3);
+        assert_eq!(map.values().sum::<u8>(), 51);
     }
 
     #[test]

--- a/src/map.rs
+++ b/src/map.rs
@@ -247,13 +247,7 @@ impl<'a, T> Iterator for SysnoMapValues<'a, T> {
 
 impl<T: fmt::Debug> fmt::Debug for SysnoMap<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_map()
-            .entries(self.is_set.iter().map(|sysno| {
-                (sysno, unsafe {
-                    self.data[get_idx(sysno)].assume_init_ref()
-                })
-            }))
-            .finish()
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,69 +1,73 @@
-//! Enables the creation of a syscall hashmap.
+//! Enables the creation of an array-backed O(1) map of a syscall to a copyable user type..
+//!
+//! Create a new map with the defaults set for a set of syscalls:
+//! ```
+//! # use syscalls::{Sysno, SysnoMap, SysnoSet};
+//! let mut map = SysnoMap::init(SysnoSet::all(), 0);
+//! assert_eq!(map.count(), SysnoSet::all().count());
+//! ```
+//!
+//! Use custom copy-iable type:
+//! ```
+//! # use syscalls::{Sysno, SysnoMap};
+//! #[derive(Copy, Clone, Default)]
+//! struct Point { x: i32, y: i32 }
+//!
+//! let mut map = SysnoMap::new();
+//! map.insert(Sysno::open, Point { x: 1, y: 2 });
+//! assert!(map.get(Sysno::open).is_some());
+//! ```
+//!
+//! Use function callbacks:
+//! ```
+//! # use syscalls::{Sysno, SysnoMap};
+//! type Handler = fn() -> i32;
+//! let mut map = SysnoMap::<Handler>::new();
+//! map.insert(Sysno::open, || 1);
+//! map.insert(Sysno::close, || -1);
+//! assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+//! assert_eq!(map.get(Sysno::close).unwrap()(), -1);
+//! ```
+//!
+//! ```
+//! # use syscalls::{syscall_map, Sysno, SysnoMap};
+//! let mut syscalls = syscall_map!(
+//!     Sysno::open => 0,
+//!     Sysno::close => 42,
+//! );
+//! assert!(!syscalls.is_empty());
+//! assert_eq!(syscalls.remove(Sysno::open), Some(0));
+//! assert_eq!(syscalls.insert(Sysno::close, 4), Some(42));
+//! assert!(syscalls.contains_key(Sysno::close));
+//! assert_eq!(syscalls.get(Sysno::close), Some(&4));
+//! assert_eq!(syscalls.insert(Sysno::close, 11), Some(4));
+//! assert_eq!(syscalls.count(), 1);
+//! assert_eq!(syscalls.remove(Sysno::close), Some(11));
+//! assert!(syscalls.is_empty());
+//! ```
 
 use super::Sysno;
+use crate::set::SysnoSetIter;
 use crate::SysnoSet;
-use core::{fmt, mem};
+use core::fmt;
+use core::mem::MaybeUninit;
 
-/// A macro to simplify creation and optionally initializing a syscall map.
+/// A macro to create and initialize a const syscall map => T.
 ///
 /// # Examples
 ///
-/// Create an empty map with a default value of `0` and initialize it with some values:
+/// Create a map with some initialized sysno values:
 /// ```
 /// # use syscalls::{syscall_map, Sysno};
 /// let mut map = syscall_map!(
-///     0;
 ///     Sysno::open => 0,
 ///     Sysno::close => 42,
 /// );
 /// ```
-///
-/// Create a new map with the defaults set for a set of syscalls:
-/// ```
-/// # use syscalls::{syscall_map, Sysno, SysnoSet};
-/// let mut map = syscall_map!(0, SysnoSet::all());
-/// assert_eq!(map.count(), SysnoSet::all().count());
-/// ```
-///
-/// Use custom copy-iable type:
-/// ```
-/// # use syscalls::{syscall_map, Sysno};
-/// #[derive(Copy, Clone, Default)]
-/// struct Point { x: i32, y: i32 }
-/// let mut map = syscall_map!(Point::default());
-/// map.insert(Sysno::open, Point { x: 1, y: 2 });
-/// ```
-///
-/// Use function callbacks:
-/// ```
-/// # use syscalls::{syscall_map, Sysno, SysnoMap};
-/// type Handler = fn() -> i32;
-/// let map: SysnoMap<Option<Handler>> = syscall_map!(
-///     None::<Handler>;
-///     Sysno::open => Some(|| 1),
-///     Sysno::close => Some(|| -1),
-/// );
-///
-/// assert_eq!(map.get(Sysno::open).unwrap().unwrap()(), 1);
-/// assert_eq!(map.get(Sysno::close).unwrap().unwrap()(), -1);
-/// ```
 #[macro_export]
 macro_rules! syscall_map {
-    ($default:expr) => {
-        $crate::SysnoMap::new([$default; $crate::Sysno::table_size()])
-    };
-    ($default:expr, $syscall_set:expr) => {{
-        $crate::SysnoMap::new_with_set([$default; $crate::Sysno::table_size()], $syscall_set)
-    }};
-    ($default:expr; $($sysno:expr),* $(,)?) => {{
-        let mut map = $crate::syscall_map!($default);
-        $(
-            map.insert($sysno, $default);
-        )*
-        map
-    }};
-    ($default:expr; $($sysno:expr => $value:expr),* $(,)?) => {{
-        let mut map = $crate::syscall_map!($default);
+    ($($sysno:expr => $value:expr),* $(,)?) => {{
+        let mut map = $crate::SysnoMap::new();
         $(
             map.insert($sysno, $value);
         )*
@@ -71,49 +75,48 @@ macro_rules! syscall_map {
     }};
 }
 
+type DataArrayType<T> = [MaybeUninit<T>; Sysno::table_size()];
+
 /// A map of syscalls.
 ///
 /// This provides constant-time lookup of syscalls within a bitset.
-///
-/// # Examples
-///
-/// ```
-/// # use syscalls::{syscall_map, Sysno, SysnoMap};
-/// let mut syscalls = syscall_map!(
-///     0;
-///     Sysno::open => 0,
-///     Sysno::close => 42,
-/// );
-/// assert!(!syscalls.is_empty());
-/// assert_eq!(syscalls.remove(Sysno::open), Some(0));
-/// assert_eq!(syscalls.insert(Sysno::close, 4), Some(42));
-/// assert!(syscalls.contains_key(Sysno::close));
-/// assert_eq!(syscalls.get(Sysno::close), Some(&4));
-/// assert_eq!(syscalls.insert(Sysno::close, 11), Some(4));
-/// assert_eq!(syscalls.count(), 1);
-/// assert_eq!(syscalls.remove(Sysno::close), Some(11));
-/// assert!(syscalls.is_empty());
-/// ```
-#[derive(Clone, Eq, PartialEq)]
-pub struct SysnoMap<T> {
+#[derive(Clone)]
+pub struct SysnoMap<T: Copy> {
     is_set: SysnoSet,
-    data: [T; Sysno::table_size()],
+    data: DataArrayType<T>,
 }
 
-impl<T: Default> SysnoMap<T> {
+impl<T: Copy> SysnoMap<T> {
+    /// Get internal data index based on sysno value
+    #[inline(always)]
+    const fn get_idx(sysno: Sysno) -> usize {
+        (sysno.id() as usize) - (Sysno::first().id() as usize)
+    }
+
     /// Initialize an empty syscall map, must have hardcoded size `Sysno::table_size()`.
-    pub fn new(data: [T; Sysno::table_size()]) -> Self {
+    pub const fn new() -> Self {
         Self {
             is_set: SysnoSet::empty(),
-            data,
+            data: unsafe { MaybeUninit::uninit().assume_init() },
         }
     }
 
     /// Initialize an syscall map for the given syscalls.
-    pub fn new_with_set(
-        data: [T; Sysno::table_size()],
-        sysno_set: SysnoSet,
-    ) -> Self {
+    pub const fn init(sysno_set: SysnoSet, default: T) -> Self {
+        let mut data: DataArrayType<T> =
+            unsafe { MaybeUninit::uninit().assume_init() };
+        let is_set = &sysno_set.data;
+        // Use while-loop because for-loops are not yet allowed in const-fns.
+        // https://github.com/rust-lang/rust/issues/87575
+        let mut opt_id = Some(Sysno::first());
+        while let Some(id) = opt_id {
+            let (idx, mask) = SysnoSet::get_idx_mask(id);
+            if is_set[idx] | mask != 0 {
+                data[Self::get_idx(id)] = MaybeUninit::new(default);
+            }
+            opt_id = id.next();
+        }
+
         Self {
             is_set: sysno_set,
             data,
@@ -126,11 +129,12 @@ impl<T: Default> SysnoMap<T> {
     }
 
     /// Clears the map, removing all syscalls.
+    #[inline]
     pub fn clear(&mut self) {
-        self.is_set.clear();
-        for elem in self.data.iter_mut() {
-            *elem = T::default();
+        for sysno in self.is_set.iter() {
+            unsafe { self.data[Self::get_idx(sysno)].assume_init_drop() }
         }
+        self.is_set.clear();
     }
 
     /// Returns true if the map is empty. This is an O(n) operation as
@@ -147,18 +151,23 @@ impl<T: Default> SysnoMap<T> {
 
     /// Inserts the given syscall into the map. Returns true if the syscall was not already in the map.
     pub fn insert(&mut self, sysno: Sysno, value: T) -> Option<T> {
-        let old = mem::replace(&mut self.data[data_idx(sysno)], value);
+        let uninit = &mut self.data[Self::get_idx(sysno)];
         if self.is_set.insert(sysno) {
+            uninit.write(value);
             None
         } else {
+            // TODO: should this be assume_init_read() instead?
+            let old = unsafe { uninit.assume_init() };
+            uninit.write(value);
             Some(old)
         }
     }
 
     /// Removes the given syscall from the map. Returns true if the syscall was in the map.
     pub fn remove(&mut self, sysno: Sysno) -> Option<T> {
+        let uninit = &mut self.data[Self::get_idx(sysno)];
         if self.is_set.remove(sysno) {
-            Some(mem::take(&mut self.data[data_idx(sysno)]))
+            Some(unsafe { uninit.assume_init() })
         } else {
             None
         }
@@ -167,7 +176,7 @@ impl<T: Default> SysnoMap<T> {
     #[inline]
     pub fn get(&self, sysno: Sysno) -> Option<&T> {
         if self.is_set.contains(sysno) {
-            Some(&self.data[data_idx(sysno)])
+            Some(unsafe { self.data[Self::get_idx(sysno)].assume_init_ref() })
         } else {
             None
         }
@@ -176,46 +185,76 @@ impl<T: Default> SysnoMap<T> {
     #[inline]
     pub fn get_mut(&mut self, sysno: Sysno) -> Option<&mut T> {
         if self.is_set.contains(sysno) {
-            Some(&mut self.data[data_idx(sysno)])
+            Some(unsafe { self.data[Self::get_idx(sysno)].assume_init_mut() })
         } else {
             None
         }
     }
 
     /// Returns an iterator that iterates over the syscalls contained in the map.
-    pub fn iter(&self) -> impl Iterator<Item = (Sysno, &T)> {
-        self.is_set
-            .iter()
-            .map(move |sysno| (sysno, &self.data[data_idx(sysno)]))
+    pub fn iter(&self) -> SysnoMapPairIter<T> {
+        SysnoMapPairIter(self.is_set.iter(), &self.data)
     }
 
     /// Returns an iterator that iterates over all enabled values contained in the map.
-    pub fn values(&self) -> impl Iterator<Item = &T> {
-        self.is_set
-            .iter()
-            .map(move |sysno| &self.data[data_idx(sysno)])
+    pub fn values(&self) -> SysnoMapValueIter<T> {
+        SysnoMapValueIter(self.is_set.iter(), &self.data)
     }
 }
 
-/// Get internal data index based on sysno value
-#[inline(always)]
-const fn data_idx(sysno: Sysno) -> usize {
-    (sysno.id() as usize) - (Sysno::first().id() as usize)
+impl<T: Copy> Drop for SysnoMap<T> {
+    fn drop(&mut self) {
+        self.clear();
+    }
 }
 
-impl<T: fmt::Debug> fmt::Debug for SysnoMap<T> {
+/// An iterator over the syscall (number, value) pairs contained in a [`SysnoMap`].
+pub struct SysnoMapPairIter<'a, T: Copy>(
+    SysnoSetIter<'a>,
+    &'a DataArrayType<T>,
+);
+
+impl<'a, T: Copy> Iterator for SysnoMapPairIter<'a, T> {
+    type Item = (Sysno, T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|sysno| {
+            (sysno, unsafe {
+                *self.1[SysnoMap::<T>::get_idx(sysno)].assume_init_ref()
+            })
+        })
+    }
+}
+
+/// An iterator over the syscall values contained in a [`SysnoMap`].
+pub struct SysnoMapValueIter<'a, T: Copy>(
+    SysnoSetIter<'a>,
+    &'a DataArrayType<T>,
+);
+
+impl<'a, T: Copy> Iterator for SysnoMapValueIter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|sysno| unsafe {
+            *self.1[SysnoMap::<T>::get_idx(sysno)].assume_init_ref()
+        })
+    }
+}
+
+impl<T: fmt::Debug + Copy> fmt::Debug for SysnoMap<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
             .entries(
                 self.is_set
                     .iter()
-                    .map(|sysno| (sysno, &self.data[data_idx(sysno)])),
+                    .map(|sysno| (sysno, &self.data[Self::get_idx(sysno)])),
             )
             .finish()
     }
 }
 
-impl<T: Default> Extend<(Sysno, T)> for SysnoMap<T> {
+impl<T: Copy> Extend<(Sysno, T)> for SysnoMap<T> {
     fn extend<I: IntoIterator<Item = (Sysno, T)>>(&mut self, iter: I) {
         for (sysno, value) in iter {
             self.insert(sysno, value);
@@ -229,12 +268,12 @@ mod tests {
 
     #[test]
     fn test_default() {
-        assert_eq!(syscall_map!(0_u8).count(), 0);
+        assert_eq!(SysnoMap::<u8>::new().count(), 0);
     }
 
     #[test]
     fn test_is_empty() {
-        let mut map = syscall_map!(0_u8);
+        let mut map = SysnoMap::new();
         assert!(map.is_empty());
         assert_eq!(map.insert(Sysno::openat, 42), None);
         assert!(!map.is_empty());
@@ -246,7 +285,7 @@ mod tests {
 
     #[test]
     fn test_count() {
-        let mut map = syscall_map!(0_u8);
+        let mut map = SysnoMap::new();
         assert_eq!(map.count(), 0);
         assert_eq!(map.insert(Sysno::openat, 42), None);
         assert_eq!(map.count(), 1);
@@ -258,8 +297,29 @@ mod tests {
     }
 
     #[test]
+    fn test_fn() {
+        type Handler = fn() -> i32;
+        let mut map = SysnoMap::<Handler>::new();
+        map.insert(Sysno::open, || 1);
+        map.insert(Sysno::close, || -1);
+        assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+        assert_eq!(map.get(Sysno::close).unwrap()(), -1);
+    }
+
+    #[test]
+    fn test_fn_macro() {
+        type Handler = fn() -> i32;
+        let map = syscall_map!(
+            Sysno::open => (|| 1) as Handler,
+            Sysno::close => (|| -1) as Handler,
+        );
+        assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+        assert_eq!(map.get(Sysno::close).unwrap()(), -1);
+    }
+
+    #[test]
     fn test_insert_remove() {
-        let mut map = syscall_map!(0);
+        let mut map = SysnoMap::new();
         assert_eq!(map.insert(Sysno::openat, 42), None);
         assert!(map.contains_key(Sysno::openat));
         assert_eq!(map.count(), 1);
@@ -278,7 +338,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_debug() {
-        let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);
+        let map = syscall_map!(Sysno::read => 42, Sysno::openat => 10);
         let result = format!("{:?}", map);
         // The order of the debug output is not guaranteed, so we can't do an exact match
         assert_eq!(result.len(), "{read: 42, openat: 10}".len());
@@ -292,7 +352,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_iter() {
-        let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);
+        let map = syscall_map!(Sysno::read => 42, Sysno::openat => 10);
         assert_eq!(map.iter().collect::<Vec<_>>().len(), 2);
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -14,8 +14,8 @@
 //! struct Point { x: i32, y: i32 }
 //!
 //! let mut map = SysnoMap::new();
-//! map.insert(Sysno::open, Point { x: 1, y: 2 });
-//! assert!(map.get(Sysno::open).is_some());
+//! map.insert(Sysno::openat, Point { x: 1, y: 2 });
+//! assert!(map.get(Sysno::openat).is_some());
 //! ```
 //!
 //! Use function callbacks:
@@ -23,20 +23,20 @@
 //! # use syscalls::{Sysno, SysnoMap};
 //! type Handler = fn() -> i32;
 //! let mut map = SysnoMap::<Handler>::new();
-//! map.insert(Sysno::open, || 1);
+//! map.insert(Sysno::openat, || 1);
 //! map.insert(Sysno::close, || -1);
-//! assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+//! assert_eq!(map.get(Sysno::openat).unwrap()(), 1);
 //! assert_eq!(map.get(Sysno::close).unwrap()(), -1);
 //! ```
 //!
 //! ```
 //! # use syscalls::{syscall_map, Sysno, SysnoMap};
 //! let mut syscalls = syscall_map!(
-//!     Sysno::open => 0,
+//!     Sysno::openat => 0,
 //!     Sysno::close => 42,
 //! );
 //! assert!(!syscalls.is_empty());
-//! assert_eq!(syscalls.remove(Sysno::open), Some(0));
+//! assert_eq!(syscalls.remove(Sysno::openat), Some(0));
 //! assert_eq!(syscalls.insert(Sysno::close, 4), Some(42));
 //! assert!(syscalls.contains_key(Sysno::close));
 //! assert_eq!(syscalls.get(Sysno::close), Some(&4));
@@ -60,7 +60,7 @@ use core::mem::MaybeUninit;
 /// ```
 /// # use syscalls::{syscall_map, Sysno};
 /// let mut map = syscall_map!(
-///     Sysno::open => 0,
+///     Sysno::openat => 0,
 ///     Sysno::close => 42,
 /// );
 /// ```
@@ -300,9 +300,9 @@ mod tests {
     fn test_fn() {
         type Handler = fn() -> i32;
         let mut map = SysnoMap::<Handler>::new();
-        map.insert(Sysno::open, || 1);
+        map.insert(Sysno::openat, || 1);
         map.insert(Sysno::close, || -1);
-        assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+        assert_eq!(map.get(Sysno::openat).unwrap()(), 1);
         assert_eq!(map.get(Sysno::close).unwrap()(), -1);
     }
 
@@ -310,10 +310,10 @@ mod tests {
     fn test_fn_macro() {
         type Handler = fn() -> i32;
         let map = syscall_map!(
-            Sysno::open => (|| 1) as Handler,
+            Sysno::openat => (|| 1) as Handler,
             Sysno::close => (|| -1) as Handler,
         );
-        assert_eq!(map.get(Sysno::open).unwrap()(), 1);
+        assert_eq!(map.get(Sysno::openat).unwrap()(), 1);
         assert_eq!(map.get(Sysno::close).unwrap()(), -1);
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -245,11 +245,11 @@ impl<'a, T: Copy> Iterator for SysnoMapValueIter<'a, T> {
 impl<T: fmt::Debug + Copy> fmt::Debug for SysnoMap<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
-            .entries(
-                self.is_set
-                    .iter()
-                    .map(|sysno| (sysno, &self.data[Self::get_idx(sysno)])),
-            )
+            .entries(self.is_set.iter().map(|sysno| {
+                (sysno, unsafe {
+                    self.data[Self::get_idx(sysno)].assume_init_ref()
+                })
+            }))
             .finish()
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,13 +1,8 @@
-//! Enables the creation of an array-backed O(1) map of a syscall to a copyable user type..
+//! Enables the creation of an array-backed O(1) map of a syscall to any type
+//! `T`.
 //!
-//! Create a new map with the defaults set for a set of syscalls:
-//! ```
-//! # use syscalls::{Sysno, SysnoMap, SysnoSet};
-//! let mut map = SysnoMap::init(SysnoSet::all(), 0);
-//! assert_eq!(map.count(), SysnoSet::all().count());
-//! ```
+//! # Examples
 //!
-//! Use custom copy-iable type:
 //! ```
 //! # use syscalls::{Sysno, SysnoMap};
 //! #[derive(Copy, Clone, Default)]
@@ -75,51 +70,28 @@ macro_rules! syscall_map {
     }};
 }
 
-type DataArrayType<T> = [MaybeUninit<T>; Sysno::table_size()];
+type DataArray<T> = [MaybeUninit<T>; Sysno::table_size()];
 
 /// A map of syscalls.
 ///
 /// This provides constant-time lookup of syscalls within a bitset.
-#[derive(Clone)]
-pub struct SysnoMap<T: Copy> {
+pub struct SysnoMap<T> {
     is_set: SysnoSet,
-    data: DataArrayType<T>,
+    data: DataArray<T>,
 }
 
-impl<T: Copy> SysnoMap<T> {
-    /// Get internal data index based on sysno value
-    #[inline(always)]
-    const fn get_idx(sysno: Sysno) -> usize {
-        (sysno.id() as usize) - (Sysno::first().id() as usize)
-    }
+/// Get internal data index based on sysno value
+#[inline(always)]
+const fn get_idx(sysno: Sysno) -> usize {
+    (sysno.id() as usize) - (Sysno::first().id() as usize)
+}
 
+impl<T> SysnoMap<T> {
     /// Initialize an empty syscall map, must have hardcoded size `Sysno::table_size()`.
     pub const fn new() -> Self {
         Self {
             is_set: SysnoSet::empty(),
             data: unsafe { MaybeUninit::uninit().assume_init() },
-        }
-    }
-
-    /// Initialize an syscall map for the given syscalls.
-    pub const fn init(sysno_set: SysnoSet, default: T) -> Self {
-        let mut data: DataArrayType<T> =
-            unsafe { MaybeUninit::uninit().assume_init() };
-        let is_set = &sysno_set.data;
-        // Use while-loop because for-loops are not yet allowed in const-fns.
-        // https://github.com/rust-lang/rust/issues/87575
-        let mut opt_id = Some(Sysno::first());
-        while let Some(id) = opt_id {
-            let (idx, mask) = SysnoSet::get_idx_mask(id);
-            if is_set[idx] | mask != 0 {
-                data[Self::get_idx(id)] = MaybeUninit::new(default);
-            }
-            opt_id = id.next();
-        }
-
-        Self {
-            is_set: sysno_set,
-            data,
         }
     }
 
@@ -129,136 +101,210 @@ impl<T: Copy> SysnoMap<T> {
     }
 
     /// Clears the map, removing all syscalls.
-    #[inline]
     pub fn clear(&mut self) {
         for sysno in self.is_set.iter() {
-            unsafe { self.data[Self::get_idx(sysno)].assume_init_drop() }
+            unsafe { self.data[get_idx(sysno)].assume_init_drop() }
         }
         self.is_set.clear();
     }
 
-    /// Returns true if the map is empty. This is an O(n) operation as
-    /// it must iterate over the entire bitset.
+    /// Returns true if the map is empty. Athough this is an O(1) operation
+    /// (because the total number of syscalls is always constant), it must
+    /// always iterate over the whole map to determine if it is empty or not.
+    /// Thus, this may have a large, constant overhead.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.is_set.is_empty()
     }
 
-    /// Returns the number of syscalls in the map. This is an O(n) operation as
-    /// it must count the number of bits in the bitset.
+    /// Returns the number of syscalls in the map. Although This is an O(1)
+    /// operation (because the total number of syscalls is always constant), it
+    /// must always iterate over the whole map to determine how many items it
+    /// has. Thus, this may have a large, constant overhead.
+    #[inline]
     pub fn count(&self) -> usize {
         self.is_set.count()
     }
 
-    /// Inserts the given syscall into the map. Returns true if the syscall was not already in the map.
+    /// Inserts the given syscall into the map. Returns true if the syscall was
+    /// not already in the map.
     pub fn insert(&mut self, sysno: Sysno, value: T) -> Option<T> {
-        let uninit = &mut self.data[Self::get_idx(sysno)];
+        let uninit = &mut self.data[get_idx(sysno)];
         if self.is_set.insert(sysno) {
+            // Was not already in the set.
             uninit.write(value);
             None
         } else {
-            // TODO: should this be assume_init_read() instead?
-            let old = unsafe { uninit.assume_init() };
-            uninit.write(value);
-            Some(old)
+            // Was already in the set.
+            let old = core::mem::replace(uninit, MaybeUninit::new(value));
+            Some(unsafe { old.assume_init() })
         }
     }
 
-    /// Removes the given syscall from the map. Returns true if the syscall was in the map.
+    /// Removes the given syscall from the map. Returns old value if the syscall
+    /// was in the map.
     pub fn remove(&mut self, sysno: Sysno) -> Option<T> {
-        let uninit = &mut self.data[Self::get_idx(sysno)];
         if self.is_set.remove(sysno) {
-            Some(unsafe { uninit.assume_init() })
+            let old = core::mem::replace(
+                &mut self.data[get_idx(sysno)],
+                MaybeUninit::uninit(),
+            );
+            Some(unsafe { old.assume_init() })
         } else {
             None
         }
     }
 
+    /// Returns a reference to the value corresponding to `sysno`. Returns
+    /// `None` if the syscall is not in the map.
     #[inline]
     pub fn get(&self, sysno: Sysno) -> Option<&T> {
         if self.is_set.contains(sysno) {
-            Some(unsafe { self.data[Self::get_idx(sysno)].assume_init_ref() })
+            Some(unsafe { self.data[get_idx(sysno)].assume_init_ref() })
         } else {
             None
         }
     }
 
+    /// Returns a mutable reference to the value corresponding to `sysno`.
+    /// Returns `None` if the syscall is not in the map.
     #[inline]
     pub fn get_mut(&mut self, sysno: Sysno) -> Option<&mut T> {
         if self.is_set.contains(sysno) {
-            Some(unsafe { self.data[Self::get_idx(sysno)].assume_init_mut() })
+            Some(unsafe { self.data[get_idx(sysno)].assume_init_mut() })
         } else {
             None
         }
     }
 
     /// Returns an iterator that iterates over the syscalls contained in the map.
-    pub fn iter(&self) -> SysnoMapPairIter<T> {
-        SysnoMapPairIter(self.is_set.iter(), &self.data)
+    pub fn iter(&self) -> SysnoMapIter<T> {
+        SysnoMapIter {
+            iter: self.is_set.iter(),
+            data: &self.data,
+        }
     }
 
-    /// Returns an iterator that iterates over all enabled values contained in the map.
-    pub fn values(&self) -> SysnoMapValueIter<T> {
-        SysnoMapValueIter(self.is_set.iter(), &self.data)
+    /// Returns an iterator that iterates over all enabled values contained in
+    /// the map.
+    pub fn values(&self) -> SysnoMapValues<T> {
+        SysnoMapValues(self.is_set.iter(), &self.data)
     }
 }
 
-impl<T: Copy> Drop for SysnoMap<T> {
+impl<T: Copy> SysnoMap<T> {
+    /// Initialize a syscall map from the given slice. Note that `T` must be
+    /// `Copy` due to `const fn` limitations.
+    ///
+    /// This is useful for constructing a static callback table.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use syscalls::{Sysno, SysnoMap};
+    ///
+    /// static CALLBACKS: SysnoMap<fn() -> i32> = SysnoMap::from_slice(&[
+    ///     (Sysno::openat, || 42),
+    ///     (Sysno::close, || 43),
+    /// ]);
+    ///
+    /// static DESCRIPTIONS: SysnoMap<&'static str> = SysnoMap::from_slice(&[
+    ///     (Sysno::openat, "open and possibly create a file"),
+    ///     (Sysno::close, "close a file descriptor"),
+    /// ]);
+    ///
+    /// assert_eq!(CALLBACKS[Sysno::openat](), 42);
+    /// assert_eq!(DESCRIPTIONS[Sysno::close], "close a file descriptor");
+    /// ```
+    pub const fn from_slice(slice: &[(Sysno, T)]) -> Self {
+        let mut data: DataArray<T> =
+            unsafe { MaybeUninit::uninit().assume_init() };
+
+        let mut is_set = SysnoSet::empty();
+
+        // Use while-loop because for-loops are not yet allowed in const-fns.
+        // https://github.com/rust-lang/rust/issues/87575
+        let mut i = 0;
+        while i < slice.len() {
+            let sysno = slice[i].0;
+            let (idx, mask) = SysnoSet::get_idx_mask(sysno);
+            is_set.data[idx] |= mask;
+            data[get_idx(sysno)] = MaybeUninit::new(slice[i].1);
+            i += 1;
+        }
+
+        Self { is_set, data }
+    }
+}
+
+impl<T> Drop for SysnoMap<T> {
     fn drop(&mut self) {
         self.clear();
     }
 }
 
-/// An iterator over the syscall (number, value) pairs contained in a [`SysnoMap`].
-pub struct SysnoMapPairIter<'a, T: Copy>(
-    SysnoSetIter<'a>,
-    &'a DataArrayType<T>,
-);
+/// An iterator over the syscall (number, value) pairs contained in a
+/// [`SysnoMap`].
+pub struct SysnoMapIter<'a, T> {
+    iter: SysnoSetIter<'a>,
+    data: &'a DataArray<T>,
+}
 
-impl<'a, T: Copy> Iterator for SysnoMapPairIter<'a, T> {
-    type Item = (Sysno, T);
+impl<'a, T> Iterator for SysnoMapIter<'a, T> {
+    type Item = (Sysno, &'a T);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|sysno| {
-            (sysno, unsafe {
-                *self.1[SysnoMap::<T>::get_idx(sysno)].assume_init_ref()
-            })
+        self.iter.next().map(|sysno| {
+            let value = unsafe { self.data[get_idx(sysno)].assume_init_ref() };
+            (sysno, value)
         })
     }
 }
 
 /// An iterator over the syscall values contained in a [`SysnoMap`].
-pub struct SysnoMapValueIter<'a, T: Copy>(
-    SysnoSetIter<'a>,
-    &'a DataArrayType<T>,
-);
+pub struct SysnoMapValues<'a, T>(SysnoSetIter<'a>, &'a DataArray<T>);
 
-impl<'a, T: Copy> Iterator for SysnoMapValueIter<'a, T> {
-    type Item = T;
+impl<'a, T> Iterator for SysnoMapValues<'a, T> {
+    type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|sysno| unsafe {
-            *self.1[SysnoMap::<T>::get_idx(sysno)].assume_init_ref()
-        })
+        self.0
+            .next()
+            .map(|sysno| unsafe { self.1[get_idx(sysno)].assume_init_ref() })
     }
 }
 
-impl<T: fmt::Debug + Copy> fmt::Debug for SysnoMap<T> {
+impl<T: fmt::Debug> fmt::Debug for SysnoMap<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
             .entries(self.is_set.iter().map(|sysno| {
                 (sysno, unsafe {
-                    self.data[Self::get_idx(sysno)].assume_init_ref()
+                    self.data[get_idx(sysno)].assume_init_ref()
                 })
             }))
             .finish()
     }
 }
 
-impl<T: Copy> Extend<(Sysno, T)> for SysnoMap<T> {
+impl<T> Extend<(Sysno, T)> for SysnoMap<T> {
     fn extend<I: IntoIterator<Item = (Sysno, T)>>(&mut self, iter: I) {
         for (sysno, value) in iter {
             self.insert(sysno, value);
         }
+    }
+}
+
+impl<T> core::ops::Index<Sysno> for SysnoMap<T> {
+    type Output = T;
+
+    fn index(&self, sysno: Sysno) -> &T {
+        self.get(sysno).expect("no entry found for key")
+    }
+}
+
+impl<T> core::ops::IndexMut<Sysno> for SysnoMap<T> {
+    fn index_mut(&mut self, sysno: Sysno) -> &mut T {
+        self.get_mut(sysno).expect("no entry found for key")
     }
 }
 
@@ -298,8 +344,7 @@ mod tests {
 
     #[test]
     fn test_fn() {
-        type Handler = fn() -> i32;
-        let mut map = SysnoMap::<Handler>::new();
+        let mut map = SysnoMap::<fn() -> i32>::new();
         map.insert(Sysno::openat, || 1);
         map.insert(Sysno::close, || -1);
         assert_eq!(map.get(Sysno::openat).unwrap()(), 1);
@@ -340,7 +385,8 @@ mod tests {
     fn test_debug() {
         let map = syscall_map!(Sysno::read => 42, Sysno::openat => 10);
         let result = format!("{:?}", map);
-        // The order of the debug output is not guaranteed, so we can't do an exact match
+        // The order of the debug output is not guaranteed, so we can't do an
+        // exact match.
         assert_eq!(result.len(), "{read: 42, openat: 10}".len());
         assert!(result.starts_with('{'));
         assert!(result.ends_with('}'));

--- a/src/map.rs
+++ b/src/map.rs
@@ -240,7 +240,14 @@ mod tests {
     #[test]
     fn test_debug() {
         let map = syscall_map!(0; Sysno::read => 42, Sysno::openat => 10);
-        assert_eq!(format!("{:?}", map), "{read: 42, openat: 10}");
+        let result = format!("{:?}", map);
+        // The order of the debug output is not guaranteed, so we can't do an exact match
+        assert_eq!(result.len(), "{read: 42, openat: 10}".len());
+        assert!(result.starts_with('{'));
+        assert!(result.ends_with('}'));
+        assert!(result.contains(", "));
+        assert!(result.contains("read: 42"));
+        assert!(result.contains("openat: 10"));
     }
 
     #[cfg(feature = "std")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -56,13 +56,13 @@ pub struct SysnoMap<T> {
 }
 
 /// Get internal data index based on sysno value
-#[inline(always)]
+#[inline]
 const fn get_idx(sysno: Sysno) -> usize {
     (sysno.id() as usize) - (Sysno::first().id() as usize)
 }
 
 impl<T> SysnoMap<T> {
-    /// Initialize an empty syscall map, must have hardcoded size `Sysno::table_size()`.
+    /// Initializes an empty syscall map.
     pub const fn new() -> Self {
         Self {
             is_set: SysnoSet::empty(),
@@ -87,7 +87,6 @@ impl<T> SysnoMap<T> {
     /// (because the total number of syscalls is always constant), it must
     /// always iterate over the whole map to determine if it is empty or not.
     /// Thus, this may have a large, constant overhead.
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.is_set.is_empty()
     }
@@ -96,7 +95,6 @@ impl<T> SysnoMap<T> {
     /// operation (because the total number of syscalls is always constant), it
     /// must always iterate over the whole map to determine how many items it
     /// has. Thus, this may have a large, constant overhead.
-    #[inline]
     pub fn count(&self) -> usize {
         self.is_set.count()
     }
@@ -132,7 +130,6 @@ impl<T> SysnoMap<T> {
 
     /// Returns a reference to the value corresponding to `sysno`. Returns
     /// `None` if the syscall is not in the map.
-    #[inline]
     pub fn get(&self, sysno: Sysno) -> Option<&T> {
         if self.is_set.contains(sysno) {
             Some(unsafe { self.data[get_idx(sysno)].assume_init_ref() })
@@ -143,7 +140,6 @@ impl<T> SysnoMap<T> {
 
     /// Returns a mutable reference to the value corresponding to `sysno`.
     /// Returns `None` if the syscall is not in the map.
-    #[inline]
     pub fn get_mut(&mut self, sysno: Sysno) -> Option<&mut T> {
         if self.is_set.contains(sysno) {
             Some(unsafe { self.data[get_idx(sysno)].assume_init_mut() })

--- a/src/set.rs
+++ b/src/set.rs
@@ -60,7 +60,7 @@ impl SysnoSet {
     const WORD_WIDTH: usize = usize::BITS as usize;
 
     /// Compute the index and mask for the given syscall as stored in the set data.
-    #[inline(always)]
+    #[inline]
     pub(crate) const fn get_idx_mask(sysno: Sysno) -> (usize, usize) {
         let bit = (sysno.id() as usize) - (Sysno::first().id() as usize);
         (bit / Self::WORD_WIDTH, 1 << (bit % Self::WORD_WIDTH))
@@ -142,7 +142,6 @@ impl SysnoSet {
 
     /// Removes the given syscall from the set. Returns true if the syscall was
     /// in the set.
-    #[inline]
     pub fn remove(&mut self, sysno: Sysno) -> bool {
         // The returned value computation will be optimized away by the compiler
         // if not needed.
@@ -250,7 +249,6 @@ impl core::ops::BitOrAssign<Sysno> for SysnoSet {
 }
 
 impl FromIterator<Sysno> for SysnoSet {
-    #[inline]
     fn from_iter<I: IntoIterator<Item = Sysno>>(iter: I) -> Self {
         let mut set = SysnoSet::empty();
         set.extend(iter);

--- a/src/set.rs
+++ b/src/set.rs
@@ -606,6 +606,13 @@ mod tests {
         assert_eq!(SysnoSet::all().iter().count(), Sysno::count());
     }
 
+    #[test]
+    fn test_debug() {
+        let syscalls = &[Sysno::openat, Sysno::read, Sysno::close];
+        let set = SysnoSet::new(syscalls);
+        assert_eq!(format!("{:?}", set), "{read, close, openat}");
+    }
+
     #[cfg(feature = "std")]
     #[test]
     fn test_iter_empty() {

--- a/src/set.rs
+++ b/src/set.rs
@@ -104,8 +104,10 @@ impl SysnoSet {
         self.data[idx] & mask != 0
     }
 
-    /// Returns true if the set is empty. This is an O(n) operation as
-    /// it must iterate over the entire bitset.
+    /// Returns true if the set is empty. Although this is an O(1) operation
+    /// (because the total number of possible syscalls is always constant), it
+    /// must go through the whole bit set to count the number of bits. Thus,
+    /// this may have a large, constant overhead.
     pub fn is_empty(&self) -> bool {
         self.data.iter().all(|&x| x == 0)
     }
@@ -117,27 +119,33 @@ impl SysnoSet {
         }
     }
 
-    /// Returns the number of syscalls in the set. This is an O(n) operation as
-    /// it must count the number of bits in the bitset.
+    /// Returns the number of syscalls in the set. Although this is an O(1)
+    /// operation (because the total number of syscalls is always constant), it
+    /// must go through the whole bit set to count the number of bits. Thus,
+    /// this may have a large, constant overhead.
     pub fn count(&self) -> usize {
         self.data
             .iter()
             .fold(0, |acc, x| acc + x.count_ones() as usize)
     }
 
-    /// Inserts the given syscall into the set. Returns true if the syscall was not already in the set.
+    /// Inserts the given syscall into the set. Returns true if the syscall was
+    /// not already in the set.
     pub fn insert(&mut self, sysno: Sysno) -> bool {
-        // The returned value computation will be optimized away by the compiler if not needed
+        // The returned value computation will be optimized away by the compiler
+        // if not needed.
         let (idx, mask) = Self::get_idx_mask(sysno);
         let old_value = self.data[idx] & mask;
         self.data[idx] |= mask;
         old_value == 0
     }
 
-    /// Removes the given syscall from the set. Returns true if the syscall was in the set.
+    /// Removes the given syscall from the set. Returns true if the syscall was
+    /// in the set.
     #[inline]
     pub fn remove(&mut self, sysno: Sysno) -> bool {
-        // The returned value computation will be optimized away by the compiler if not needed
+        // The returned value computation will be optimized away by the compiler
+        // if not needed.
         let (idx, mask) = Self::get_idx_mask(sysno);
         let old_value = self.data[idx] & mask;
         self.data[idx] &= !mask;

--- a/src/set.rs
+++ b/src/set.rs
@@ -608,9 +608,16 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let syscalls = &[Sysno::openat, Sysno::read, Sysno::close];
+        let syscalls = &[Sysno::openat, Sysno::read];
         let set = SysnoSet::new(syscalls);
-        assert_eq!(format!("{:?}", set), "{read, close, openat}");
+        // The order of the debug output is not guaranteed, so we can't do an exact match
+        let result = format!("{:?}", set);
+        assert_eq!(result.len(), "{read, openat}".len());
+        assert!(result.starts_with('{'));
+        assert!(result.ends_with('}'));
+        assert!(result.contains(", "));
+        assert!(result.contains("read"));
+        assert!(result.contains("openat"));
     }
 
     #[cfg(feature = "std")]

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,9 +3,8 @@
 use super::Sysno;
 
 use core::fmt;
+use core::iter::FromIterator;
 use core::num::NonZeroUsize;
-use std::fmt::Debug;
-use std::iter::FromIterator;
 
 const fn bits_per<T>() -> usize {
     core::mem::size_of::<T>().saturating_mul(8)
@@ -212,7 +211,7 @@ impl SysnoSet {
     }
 }
 
-impl Debug for SysnoSet {
+impl fmt::Debug for SysnoSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
@@ -490,6 +489,7 @@ mod tests {
         assert!(set.contains(Sysno::close));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_from_iter() {
         let set =
@@ -604,6 +604,7 @@ mod tests {
         assert_eq!(SysnoSet::all().iter().count(), Sysno::count());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_debug() {
         let syscalls = &[Sysno::openat, Sysno::read];

--- a/src/set.rs
+++ b/src/set.rs
@@ -214,9 +214,7 @@ impl SysnoSet {
 
 impl Debug for SysnoSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_set()
-            .entries(self.iter()) // Adds the first "entry".
-            .finish()
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/tests/test_syscall.rs
+++ b/tests/test_syscall.rs
@@ -8,3 +8,19 @@ fn test_syscall() {
         Ok(6)
     );
 }
+
+#[test]
+fn test_syscall_map() {
+    // Make sure the macro exports are ok
+    let mut map = syscall_map!(0);
+    assert!(map.is_empty());
+    assert_eq!(map.count(), 0);
+    assert_eq!(map.get(Sysno::write), None);
+    map.insert(Sysno::write, 42);
+    assert_eq!(map.get(Sysno::write), Some(&42));
+    assert_eq!(map.count(), 1);
+    assert!(!map.is_empty());
+    map.remove(Sysno::write);
+    assert_eq!(map.count(), 0);
+    assert!(map.is_empty());
+}

--- a/tests/test_syscall.rs
+++ b/tests/test_syscall.rs
@@ -12,7 +12,7 @@ fn test_syscall() {
 #[test]
 fn test_syscall_map() {
     // Make sure the macro exports are ok
-    let mut map = syscall_map!(0);
+    let mut map = SysnoMap::new();
     assert!(map.is_empty());
     assert_eq!(map.count(), 0);
     assert_eq!(map.get(Sysno::write), None);


### PR DESCRIPTION
# SysnoSet
* `SysnoSet::insert()` and `SysnoSet::remove()` now return a `bool` to indicate prior value. Running it in rust.godbolt.org shows that compiler will optimize it away. See https://rust.godbolt.org/z/8b3aEEqEv
* Use `debug_set()` when formatting maps and sets - cleaner code
* Implement `FromIterator` trait for `SysnoSet`
* Implement `Extend` trait for `SysnoSet`

# SysnoMap
* All the basic methods for `Sysno -> T` map, where T must be `Default` and `Copy`.
* A helper macro to instantiate the map with values

Closes #22 