### PR TITLE
Fix a typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
         target_arch = "mips64",
         target_arch = "s390x",
         target_arch = "powerpc",
-        target_arch = "powerpc65",
+        target_arch = "powerpc64",
     ),
     feature(asm_experimental_arch)
 )]


### PR DESCRIPTION
Fix a typo in cfg_attr for asm_experimental_arch, powerpc64 was mispelled