### PR TITLE
Add fetch for arch-specific syscalls

### DIFF
--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -492,6 +492,8 @@ syscall_enum! {
         accept4 = 242,
         /// See [recvmmsg(2)](https://man7.org/linux/man-pages/man2/recvmmsg.2.html) for more info on this syscall.
         recvmmsg = 243,
+        /// See [riscv_flush_icache(2)](https://man7.org/linux/man-pages/man2/riscv_flush_icache.2.html) for more info on this syscall.
+        riscv_flush_icache = 259,
         /// See [wait4(2)](https://man7.org/linux/man-pages/man2/wait4.2.html) for more info on this syscall.
         wait4 = 260,
         /// See [prlimit64(2)](https://man7.org/linux/man-pages/man2/prlimit64.2.html) for more info on this syscall.

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -492,6 +492,8 @@ syscall_enum! {
         accept4 = 242,
         /// See [recvmmsg(2)](https://man7.org/linux/man-pages/man2/recvmmsg.2.html) for more info on this syscall.
         recvmmsg = 243,
+        /// See [riscv_flush_icache(2)](https://man7.org/linux/man-pages/man2/riscv_flush_icache.2.html) for more info on this syscall.
+        riscv_flush_icache = 259,
         /// See [wait4(2)](https://man7.org/linux/man-pages/man2/wait4.2.html) for more info on this syscall.
         wait4 = 260,
         /// See [prlimit64(2)](https://man7.org/linux/man-pages/man2/prlimit64.2.html) for more info on this syscall.

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -93,7 +93,7 @@ lazy_static! {
             arch: "riscv32",
             headers: &[
                 "include/uapi/asm-generic/unistd.h",
-                // "arch/riscv/include/uapi/asm/unistd.h",
+                "arch/riscv/include/uapi/asm/unistd.h",
             ],
             blocklist: &["sync_file_range"],
         }),
@@ -101,7 +101,7 @@ lazy_static! {
             arch: "riscv64",
             headers: &[
                 "include/uapi/asm-generic/unistd.h",
-                // "arch/riscv/include/uapi/asm/unistd.h",
+                "arch/riscv/include/uapi/asm/unistd.h",
             ],
             blocklist: &["sync_file_range"],
         }),


### PR DESCRIPTION
RISC-V has used the reserved area for `riscv_flush_icache` (and later `riscv_hwprobe`). Add them to `Sysno` as well.

See https://github.com/torvalds/linux/blob/master/arch/riscv/include/uapi/asm/unistd.h.