### PR TITLE
Bump Linux version to v6.5

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -656,6 +656,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -810,6 +810,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/mips.rs
+++ b/src/arch/mips.rs
@@ -852,6 +852,8 @@ syscall_enum! {
         futex_waitv = 4449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 4450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 4451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/mips64.rs
+++ b/src/arch/mips64.rs
@@ -710,6 +710,8 @@ syscall_enum! {
         process_mrelease = 5448,
         /// See [futex_waitv(2)](https://man7.org/linux/man-pages/man2/futex_waitv.2.html) for more info on this syscall.
         futex_waitv = 5449,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 5451,
     }
-    LAST: futex_waitv;
+    LAST: cachestat;
 }

--- a/src/arch/powerpc.rs
+++ b/src/arch/powerpc.rs
@@ -866,6 +866,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/powerpc64.rs
+++ b/src/arch/powerpc64.rs
@@ -810,6 +810,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -492,6 +492,8 @@ syscall_enum! {
         accept4 = 242,
         /// See [recvmmsg(2)](https://man7.org/linux/man-pages/man2/recvmmsg.2.html) for more info on this syscall.
         recvmmsg = 243,
+        /// See [riscv_hwprobe(2)](https://man7.org/linux/man-pages/man2/riscv_hwprobe.2.html) for more info on this syscall.
+        riscv_hwprobe = 258,
         /// See [riscv_flush_icache(2)](https://man7.org/linux/man-pages/man2/riscv_flush_icache.2.html) for more info on this syscall.
         riscv_flush_icache = 259,
         /// See [wait4(2)](https://man7.org/linux/man-pages/man2/wait4.2.html) for more info on this syscall.
@@ -658,6 +660,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -492,6 +492,8 @@ syscall_enum! {
         accept4 = 242,
         /// See [recvmmsg(2)](https://man7.org/linux/man-pages/man2/recvmmsg.2.html) for more info on this syscall.
         recvmmsg = 243,
+        /// See [riscv_hwprobe(2)](https://man7.org/linux/man-pages/man2/riscv_hwprobe.2.html) for more info on this syscall.
+        riscv_hwprobe = 258,
         /// See [riscv_flush_icache(2)](https://man7.org/linux/man-pages/man2/riscv_flush_icache.2.html) for more info on this syscall.
         riscv_flush_icache = 259,
         /// See [wait4(2)](https://man7.org/linux/man-pages/man2/wait4.2.html) for more info on this syscall.
@@ -658,6 +660,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/s390x.rs
+++ b/src/arch/s390x.rs
@@ -734,12 +734,16 @@ syscall_enum! {
         landlock_add_rule = 445,
         /// See [landlock_restrict_self(2)](https://man7.org/linux/man-pages/man2/landlock_restrict_self.2.html) for more info on this syscall.
         landlock_restrict_self = 446,
+        /// See [memfd_secret(2)](https://man7.org/linux/man-pages/man2/memfd_secret.2.html) for more info on this syscall.
+        memfd_secret = 447,
         /// See [process_mrelease(2)](https://man7.org/linux/man-pages/man2/process_mrelease.2.html) for more info on this syscall.
         process_mrelease = 448,
         /// See [futex_waitv(2)](https://man7.org/linux/man-pages/man2/futex_waitv.2.html) for more info on this syscall.
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/sparc.rs
+++ b/src/arch/sparc.rs
@@ -842,6 +842,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/sparc64.rs
+++ b/src/arch/sparc64.rs
@@ -768,6 +768,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -884,6 +884,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -728,6 +728,8 @@ syscall_enum! {
         futex_waitv = 449,
         /// See [set_mempolicy_home_node(2)](https://man7.org/linux/man-pages/man2/set_mempolicy_home_node.2.html) for more info on this syscall.
         set_mempolicy_home_node = 450,
+        /// See [cachestat(2)](https://man7.org/linux/man-pages/man2/cachestat.2.html) for more info on this syscall.
+        cachestat = 451,
     }
-    LAST: set_mempolicy_home_node;
+    LAST: cachestat;
 }

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -17,7 +17,7 @@ mod tables;
 static LINUX_REPO: &str = "https://raw.githubusercontent.com/torvalds/linux";
 
 /// Linux version to pull the syscall tables from.
-static LINUX_VERSION: &str = "v6.2";
+static LINUX_VERSION: &str = "v6.5";
 
 lazy_static! {
     /// List of syscall tables for each architecture.


### PR DESCRIPTION
This brings in Linux's new general syscall `cachestat`, as well as RISC-V's `riscv_hwprobe`.