### PR TITLE
Remove MIPS from CI test_nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,10 @@ jobs:
           - armv7-unknown-linux-gnueabi
           - thumbv7neon-linux-androideabi
           - thumbv7neon-unknown-linux-gnueabihf
-          - mips-unknown-linux-gnu
-          - mips64-unknown-linux-gnuabi64
-          - mipsel-unknown-linux-gnu
-          - mips64el-unknown-linux-gnuabi64
+            #- mips-unknown-linux-gnu
+            #- mips64-unknown-linux-gnuabi64
+            #- mipsel-unknown-linux-gnu
+            #- mips64el-unknown-linux-gnuabi64
           - powerpc-unknown-linux-gnu
             #- powerpc64-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu


### PR DESCRIPTION
[MIPS has been downgraded to Tier 3](https://github.com/rust-lang/compiler-team/issues/648) (document not updated yet), so there's no nightly binary for mips{,64}{,el}.