### PR TITLE
Remove unnecessary build dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ serde = ["dep:serde", "serde_repr"]
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_repr = { version = "0.1", optional = true }
 
-[build-dependencies]
-cc = "1.0"
-
 [dev-dependencies]
 libc = "0.2"
 serde_json = "1"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,7 +10,7 @@
 /// ```
 /// use syscalls::{Sysno, syscall};
 ///
-/// match unsafe { syscall!(Sysno::fork) } {
+/// match unsafe { syscall!(Sysno::clone) } {
 ///     Ok(0) => {
 ///         // Child process
 ///     }
@@ -18,7 +18,7 @@
 ///         // Parent process
 ///     }
 ///     Err(err) => {
-///         eprintln!("fork() failed: {}", err);
+///         eprintln!("clone() failed: {}", err);
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
The code that used cc was removed in 550da7d. This PR removes it from build-dependencies, and the empty build dependencies section from Cargo.toml.

It also changes a doctest from using `fork` to  using `clone` as `fork` does not exist on `aarch64`.
This allows (doc)tests to pass on aarch64 linux as well as x86_64.
  
