### PR TITLE
Switching Sysno to usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod raw {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall0(nr: Sysno) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall0(nr))
+    Errno::from_ret(raw::syscall0(nr as usize))
 }
 
 /// Issues a system call with 1 argument.
@@ -73,7 +73,7 @@ pub unsafe fn syscall0(nr: Sysno) -> Result<usize, Errno> {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall1(nr: Sysno, a1: usize) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall1(nr, a1))
+    Errno::from_ret(raw::syscall1(nr as usize, a1))
 }
 
 /// Issues a system call with 2 arguments.
@@ -88,7 +88,7 @@ pub unsafe fn syscall2(
     a1: usize,
     a2: usize,
 ) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall2(nr, a1, a2))
+    Errno::from_ret(raw::syscall2(nr as usize, a1, a2))
 }
 
 /// Issues a system call with 3 arguments.
@@ -104,7 +104,7 @@ pub unsafe fn syscall3(
     a2: usize,
     a3: usize,
 ) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall3(nr, a1, a2, a3))
+    Errno::from_ret(raw::syscall3(nr as usize, a1, a2, a3))
 }
 
 /// Issues a system call with 4 arguments.
@@ -121,7 +121,7 @@ pub unsafe fn syscall4(
     a3: usize,
     a4: usize,
 ) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall4(nr, a1, a2, a3, a4))
+    Errno::from_ret(raw::syscall4(nr as usize, a1, a2, a3, a4))
 }
 
 /// Issues a system call with 5 arguments.
@@ -139,7 +139,7 @@ pub unsafe fn syscall5(
     a4: usize,
     a5: usize,
 ) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall5(nr, a1, a2, a3, a4, a5))
+    Errno::from_ret(raw::syscall5(nr as usize, a1, a2, a3, a4, a5))
 }
 
 /// Issues a system call with 6 arguments.
@@ -158,7 +158,7 @@ pub unsafe fn syscall6(
     a5: usize,
     a6: usize,
 ) -> Result<usize, Errno> {
-    Errno::from_ret(raw::syscall6(nr, a1, a2, a3, a4, a5, a6))
+    Errno::from_ret(raw::syscall6(nr as usize, a1, a2, a3, a4, a5, a6))
 }
 
 /// Does a raw syscall.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -91,24 +91,29 @@ macro_rules! syscall {
 #[macro_export]
 macro_rules! raw_syscall {
     ($nr:expr) => {
-        $crate::raw::syscall0($nr)
+        $crate::raw::syscall0($nr as usize)
     };
 
     ($nr:expr, $a1:expr) => {
-        $crate::raw::syscall1($nr, $a1 as usize)
+        $crate::raw::syscall1($nr as usize, $a1 as usize)
     };
 
     ($nr:expr, $a1:expr, $a2:expr) => {
-        $crate::raw::syscall2($nr, $a1 as usize, $a2 as usize)
+        $crate::raw::syscall2($nr as usize, $a1 as usize, $a2 as usize)
     };
 
     ($nr:expr, $a1:expr, $a2:expr, $a3:expr) => {
-        $crate::raw::syscall3($nr, $a1 as usize, $a2 as usize, $a3 as usize)
+        $crate::raw::syscall3(
+            $nr as usize,
+            $a1 as usize,
+            $a2 as usize,
+            $a3 as usize,
+        )
     };
 
     ($nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr) => {
         $crate::raw::syscall4(
-            $nr,
+            $nr as usize,
             $a1 as usize,
             $a2 as usize,
             $a3 as usize,
@@ -118,7 +123,7 @@ macro_rules! raw_syscall {
 
     ($nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr) => {
         $crate::raw::syscall5(
-            $nr,
+            $nr as usize,
             $a1 as usize,
             $a2 as usize,
             $a3 as usize,
@@ -129,7 +134,7 @@ macro_rules! raw_syscall {
 
     ($nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr) => {
         $crate::raw::syscall6(
-            $nr,
+            $nr as usize,
             $a1 as usize,
             $a2 as usize,
             $a3 as usize,

--- a/src/syscall/aarch64.rs
+++ b/src/syscall/aarch64.rs
@@ -13,8 +13,6 @@
 // No other registers are clobbered.
 use core::arch::asm;
 
-use crate::arch::aarch64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::aarch64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         lateout("x0") ret,
         options(nostack, preserves_flags)
     );
@@ -40,11 +38,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         options(nostack, preserves_flags)
     );
@@ -58,11 +56,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         in("x1") arg2,
         options(nostack, preserves_flags)
@@ -78,7 +76,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -86,7 +84,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         in("x1") arg2,
         in("x2") arg3,
@@ -103,7 +101,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -112,7 +110,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         in("x1") arg2,
         in("x2") arg3,
@@ -130,7 +128,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -140,7 +138,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         in("x1") arg2,
         in("x2") arg3,
@@ -159,7 +157,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -170,7 +168,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("x8") n as usize,
+        in("x8") n,
         inlateout("x0") arg1 => ret,
         in("x1") arg2,
         in("x2") arg3,

--- a/src/syscall/arm.rs
+++ b/src/syscall/arm.rs
@@ -13,8 +13,6 @@
 // No other registers are clobbered.
 use core::arch::asm;
 
-use crate::arch::arm::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::arm::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         lateout("r0") ret,
         options(nostack, preserves_flags)
     );
@@ -40,11 +38,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         options(nostack, preserves_flags)
     );
@@ -58,11 +56,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
         options(nostack, preserves_flags)
@@ -78,7 +76,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -86,7 +84,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
         in("r2") arg3,
@@ -103,7 +101,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -112,7 +110,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
         in("r2") arg3,
@@ -130,7 +128,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -140,7 +138,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
         in("r2") arg3,
@@ -159,7 +157,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -170,7 +168,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "svc 0",
-        in("r7") n as usize,
+        in("r7") n,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
         in("r2") arg3,

--- a/src/syscall/arm_thumb.rs
+++ b/src/syscall/arm_thumb.rs
@@ -14,8 +14,6 @@
 // No other registers are clobbered.
 use core::arch::asm;
 
-use crate::arch::arm::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -23,14 +21,14 @@ use crate::arch::arm::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "movs {temp}, r7",
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         lateout("r0") ret,
         options(nostack)
@@ -45,14 +43,14 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "movs {temp}, r7",
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         options(nostack)
@@ -67,14 +65,14 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "movs {temp}, r7",
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
@@ -91,7 +89,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -102,7 +100,7 @@ pub unsafe fn syscall3(
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
@@ -120,7 +118,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -132,7 +130,7 @@ pub unsafe fn syscall4(
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
@@ -151,7 +149,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -164,7 +162,7 @@ pub unsafe fn syscall5(
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,
@@ -184,7 +182,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -200,7 +198,7 @@ pub unsafe fn syscall6(
         "movs r7, {n}",
         "svc 0",
         "movs r7, {temp}",
-        n = in(reg) n as usize,
+        n = in(reg) n,
         temp = out(reg) _,
         inlateout("r0") arg1 => ret,
         in("r1") arg2,

--- a/src/syscall/mips.rs
+++ b/src/syscall/mips.rs
@@ -32,8 +32,6 @@
 // All temporary registers are clobbered (8-15, 24-25).
 use core::arch::asm;
 
-use crate::arch::mips::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -41,12 +39,12 @@ use crate::arch::mips::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         // All temporary registers are always clobbered
         lateout("$8") _,
@@ -75,12 +73,12 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         // All temporary registers are always clobbered
@@ -110,12 +108,12 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         in("$5") arg2,
@@ -147,7 +145,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -156,7 +154,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         in("$5") arg2,
@@ -189,7 +187,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -199,7 +197,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,
@@ -233,7 +231,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -254,7 +252,7 @@ pub unsafe fn syscall5(
         "addu $sp, 32", // Restore the stack.
         ".set at",
         arg5 = in(reg) arg5,
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,
@@ -288,7 +286,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -313,7 +311,7 @@ pub unsafe fn syscall6(
         ".set at",
         arg5 = in(reg) arg5,
         arg6 = in(reg) arg6,
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,
@@ -348,7 +346,7 @@ pub unsafe fn syscall6(
 #[allow(unused)]
 #[inline]
 pub unsafe fn syscall7(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -376,7 +374,7 @@ pub unsafe fn syscall7(
         arg5 = in(reg) arg5,
         arg6 = in(reg) arg6,
         arg7 = in(reg) arg7,
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,

--- a/src/syscall/mips64.rs
+++ b/src/syscall/mips64.rs
@@ -34,8 +34,6 @@
 // and t1, which still get clobbered.
 use core::arch::asm;
 
-use crate::arch::mips64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -43,12 +41,12 @@ use crate::arch::mips64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         // All temporary registers are always clobbered
         lateout("$8") _,
@@ -77,12 +75,12 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         // All temporary registers are always clobbered
@@ -112,12 +110,12 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut err: usize;
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         in("$5") arg2,
@@ -149,7 +147,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -158,7 +156,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         lateout("$7") err,
         in("$4") arg1,
         in("$5") arg2,
@@ -191,7 +189,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -201,7 +199,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,
@@ -235,7 +233,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -246,7 +244,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,
@@ -280,7 +278,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -292,7 +290,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("$2") n as usize => ret,
+        inlateout("$2") n => ret,
         in("$4") arg1,
         in("$5") arg2,
         in("$6") arg3,

--- a/src/syscall/powerpc.rs
+++ b/src/syscall/powerpc.rs
@@ -16,8 +16,6 @@
 // (cr0). This is then used to decide if the return value should be negated.
 use core::arch::asm;
 
-use crate::arch::powerpc::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -25,14 +23,14 @@ use crate::arch::powerpc::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         lateout("r3") ret,
         lateout("r4") _,
         lateout("r5") _,
@@ -56,14 +54,14 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         lateout("r4") _,
         lateout("r5") _,
@@ -87,14 +85,14 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         lateout("r5") _,
@@ -119,7 +117,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -130,7 +128,7 @@ pub unsafe fn syscall3(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -155,7 +153,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -167,7 +165,7 @@ pub unsafe fn syscall4(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -192,7 +190,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -205,7 +203,7 @@ pub unsafe fn syscall5(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -230,7 +228,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -244,7 +242,7 @@ pub unsafe fn syscall6(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,

--- a/src/syscall/powerpc64.rs
+++ b/src/syscall/powerpc64.rs
@@ -16,8 +16,6 @@
 // (cr0). This is then used to decide if the return value should be negated.
 use core::arch::asm;
 
-use crate::arch::powerpc64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -25,14 +23,14 @@ use crate::arch::powerpc64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         lateout("r3") ret,
         lateout("r4") _,
         lateout("r5") _,
@@ -56,14 +54,14 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         lateout("r4") _,
         lateout("r5") _,
@@ -87,14 +85,14 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "sc",
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         lateout("r5") _,
@@ -119,7 +117,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -130,7 +128,7 @@ pub unsafe fn syscall3(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -155,7 +153,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -167,7 +165,7 @@ pub unsafe fn syscall4(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -192,7 +190,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -205,7 +203,7 @@ pub unsafe fn syscall5(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,
@@ -230,7 +228,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -244,7 +242,7 @@ pub unsafe fn syscall6(
         "bns 1f",
         "neg 3, 3",
         "1:",
-        inlateout("r0") n as usize => _,
+        inlateout("r0") n => _,
         inlateout("r3") arg1 => ret,
         inlateout("r4") arg2 => _,
         inlateout("r5") arg3 => _,

--- a/src/syscall/riscv32.rs
+++ b/src/syscall/riscv32.rs
@@ -13,8 +13,6 @@
 // No other registers are clobbered.
 use core::arch::asm;
 
-use crate::arch::riscv64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::riscv64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         out("a0") ret,
         options(nostack, preserves_flags)
     );
@@ -40,11 +38,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         options(nostack, preserves_flags)
     );
@@ -58,11 +56,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         options(nostack, preserves_flags)
@@ -78,7 +76,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -86,7 +84,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -103,7 +101,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -112,7 +110,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -130,7 +128,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -140,7 +138,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -159,7 +157,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -170,7 +168,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,

--- a/src/syscall/riscv64.rs
+++ b/src/syscall/riscv64.rs
@@ -13,8 +13,6 @@
 // No other registers are clobbered.
 use core::arch::asm;
 
-use crate::arch::riscv64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::riscv64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         out("a0") ret,
         options(nostack, preserves_flags)
     );
@@ -40,11 +38,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         options(nostack, preserves_flags)
     );
@@ -58,11 +56,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         options(nostack, preserves_flags)
@@ -78,7 +76,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -86,7 +84,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -103,7 +101,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -112,7 +110,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -130,7 +128,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -140,7 +138,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,
@@ -159,7 +157,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -170,7 +168,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "ecall",
-        in("a7") n as usize,
+        in("a7") n,
         inlateout("a0") arg1 => ret,
         in("a1") arg2,
         in("a2") arg3,

--- a/src/syscall/s390x.rs
+++ b/src/syscall/s390x.rs
@@ -14,8 +14,6 @@
 // option is specified.
 use core::arch::asm;
 
-use crate::arch::s390x::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -23,12 +21,12 @@ use crate::arch::s390x::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline(always)]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
         out("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
     );
     ret
 }
@@ -40,12 +38,12 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline(always)]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
     );
     ret
@@ -58,12 +56,12 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline(always)]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
         in("r3") arg2,
     );
@@ -78,7 +76,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline(always)]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -87,7 +85,7 @@ pub unsafe fn syscall3(
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
         in("r3") arg2,
         in("r4") arg3,
@@ -103,7 +101,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline(always)]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -113,7 +111,7 @@ pub unsafe fn syscall4(
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
         in("r3") arg2,
         in("r4") arg3,
@@ -130,7 +128,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline(always)]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -141,7 +139,7 @@ pub unsafe fn syscall5(
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
         in("r3") arg2,
         in("r4") arg3,
@@ -159,7 +157,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline(always)]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -171,7 +169,7 @@ pub unsafe fn syscall6(
     asm!(
         "svc 0",
         lateout("r2") ret,
-        in("r1") n as usize,
+        in("r1") n,
         in("r2") arg1,
         in("r3") arg2,
         in("r4") arg3,

--- a/src/syscall/x86.rs
+++ b/src/syscall/x86.rs
@@ -13,8 +13,6 @@
 // option is specified.
 use core::arch::asm;
 
-use crate::arch::x86::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::x86::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "int 0x80",
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         options(nostack, preserves_flags)
     );
     ret
@@ -39,11 +37,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "int 0x80",
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         in("ebx") arg1,
         options(nostack, preserves_flags)
     );
@@ -57,11 +55,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "int 0x80",
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         in("ebx") arg1,
         in("ecx") arg2,
         options(nostack, preserves_flags)
@@ -77,7 +75,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -85,7 +83,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "int 0x80",
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         in("ebx") arg1,
         in("ecx") arg2,
         in("edx") arg3,
@@ -102,7 +100,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -116,7 +114,7 @@ pub unsafe fn syscall4(
         // Using esi is not allowed, so we need to use another register to
         // save/restore esi. Thus, we can say that esi is not clobbered.
         arg4 = in(reg) arg4,
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         in("ebx") arg1,
         in("ecx") arg2,
         in("edx") arg3,
@@ -133,7 +131,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -148,7 +146,7 @@ pub unsafe fn syscall5(
         // Using esi is not allowed, so we need to use another register to
         // save/restore esi. Thus, we can say that esi is not clobbered.
         arg4 = in(reg) arg4,
-        inlateout("eax") n as usize => ret,
+        inlateout("eax") n => ret,
         in("ebx") arg1,
         in("ecx") arg2,
         in("edx") arg3,
@@ -166,7 +164,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -189,7 +187,7 @@ pub unsafe fn syscall6(
         "pop esi",
         "pop ebp",
         // Set eax to a pointer to our input array.
-        inout("eax") &[arg4, arg6, n as usize] => ret,
+        inout("eax") &[arg4, arg6, n] => ret,
         in("ebx") arg1,
         in("ecx") arg2,
         in("edx") arg3,

--- a/src/syscall/x86_64.rs
+++ b/src/syscall/x86_64.rs
@@ -13,8 +13,6 @@
 // option is specified.
 use core::arch::asm;
 
-use crate::arch::x86_64::Sysno;
-
 /// Issues a raw system call with 0 arguments.
 ///
 /// # Safety
@@ -22,11 +20,11 @@ use crate::arch::x86_64::Sysno;
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall0(n: Sysno) -> usize {
+pub unsafe fn syscall0(n: usize) -> usize {
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         out("rcx") _, // rcx is used to store old rip
         out("r11") _, // r11 is used to store old rflags
         options(nostack, preserves_flags)
@@ -41,11 +39,11 @@ pub unsafe fn syscall0(n: Sysno) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         out("rcx") _, // rcx is used to store old rip
         out("r11") _, // r11 is used to store old rflags
@@ -61,11 +59,11 @@ pub unsafe fn syscall1(n: Sysno, arg1: usize) -> usize {
 /// Running a system call is inherently unsafe. It is the caller's
 /// responsibility to ensure safety.
 #[inline]
-pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         in("rsi") arg2,
         out("rcx") _, // rcx is used to store old rip
@@ -83,7 +81,7 @@ pub unsafe fn syscall2(n: Sysno, arg1: usize, arg2: usize) -> usize {
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall3(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -91,7 +89,7 @@ pub unsafe fn syscall3(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         in("rsi") arg2,
         in("rdx") arg3,
@@ -110,7 +108,7 @@ pub unsafe fn syscall3(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall4(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -119,7 +117,7 @@ pub unsafe fn syscall4(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         in("rsi") arg2,
         in("rdx") arg3,
@@ -139,7 +137,7 @@ pub unsafe fn syscall4(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall5(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -149,7 +147,7 @@ pub unsafe fn syscall5(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         in("rsi") arg2,
         in("rdx") arg3,
@@ -170,7 +168,7 @@ pub unsafe fn syscall5(
 /// responsibility to ensure safety.
 #[inline]
 pub unsafe fn syscall6(
-    n: Sysno,
+    n: usize,
     arg1: usize,
     arg2: usize,
     arg3: usize,
@@ -181,7 +179,7 @@ pub unsafe fn syscall6(
     let mut ret: usize;
     asm!(
         "syscall",
-        inlateout("rax") n as usize => ret,
+        inlateout("rax") n => ret,
         in("rdi") arg1,
         in("rsi") arg2,
         in("rdx") arg3,


### PR DESCRIPTION
Hello, I've come across this project while working through a personal project and saw the request for PR on #46, I figured to do it since I'd already read up on the codebase.
The guidelines were helpful and the codebase currently uses `usize` instead of `Sysno`, this is of course in the `raw` parts.
I've tested the current changes on an x86 machine, and all public apis are functioning correctly.