### PR TITLE
Bump Linux kernel ver to 6.10

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -678,6 +678,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -832,6 +832,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -678,6 +678,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/mips.rs
+++ b/src/arch/mips.rs
@@ -874,6 +874,8 @@ syscall_enum! {
         lsm_set_self_attr = 4460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 4461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 4462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/mips64.rs
+++ b/src/arch/mips64.rs
@@ -732,6 +732,8 @@ syscall_enum! {
         lsm_set_self_attr = 5460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 5461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 5462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/powerpc.rs
+++ b/src/arch/powerpc.rs
@@ -888,6 +888,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/powerpc64.rs
+++ b/src/arch/powerpc64.rs
@@ -832,6 +832,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -682,6 +682,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -682,6 +682,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/s390x.rs
+++ b/src/arch/s390x.rs
@@ -764,6 +764,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/sparc.rs
+++ b/src/arch/sparc.rs
@@ -864,6 +864,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/sparc64.rs
+++ b/src/arch/sparc64.rs
@@ -790,6 +790,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -906,6 +906,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -750,6 +750,8 @@ syscall_enum! {
         lsm_set_self_attr = 460,
         /// See [lsm_list_modules(2)](https://man7.org/linux/man-pages/man2/lsm_list_modules.2.html) for more info on this syscall.
         lsm_list_modules = 461,
+        /// See [mseal(2)](https://man7.org/linux/man-pages/man2/mseal.2.html) for more info on this syscall.
+        mseal = 462,
     }
-    LAST: lsm_list_modules;
+    LAST: mseal;
 }

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -17,7 +17,7 @@ mod tables;
 static LINUX_REPO: &str = "https://raw.githubusercontent.com/torvalds/linux";
 
 /// Linux version to pull the syscall tables from.
-static LINUX_VERSION: &str = "v6.8";
+static LINUX_VERSION: &str = "v6.10";
 
 lazy_static! {
     /// List of syscall tables for each architecture.


### PR DESCRIPTION
this PR bumps targeted Linux kernel version to 6.10, which brings new syscall `mseal()`