### PR TITLE
Fix nonexistent `sync_file_range2` syscall bug in aarch64,loongarch64 and riscv*

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -172,8 +172,8 @@ syscall_enum! {
         fsync = 82,
         /// See [fdatasync(2)](https://man7.org/linux/man-pages/man2/fdatasync.2.html) for more info on this syscall.
         fdatasync = 83,
-        /// See [sync_file_range2(2)](https://man7.org/linux/man-pages/man2/sync_file_range2.2.html) for more info on this syscall.
-        sync_file_range2 = 84,
+        /// See [sync_file_range(2)](https://man7.org/linux/man-pages/man2/sync_file_range.2.html) for more info on this syscall.
+        sync_file_range = 84,
         /// See [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html) for more info on this syscall.
         timerfd_create = 85,
         /// See [timerfd_settime(2)](https://man7.org/linux/man-pages/man2/timerfd_settime.2.html) for more info on this syscall.

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -172,8 +172,8 @@ syscall_enum! {
         fsync = 82,
         /// See [fdatasync(2)](https://man7.org/linux/man-pages/man2/fdatasync.2.html) for more info on this syscall.
         fdatasync = 83,
-        /// See [sync_file_range2(2)](https://man7.org/linux/man-pages/man2/sync_file_range2.2.html) for more info on this syscall.
-        sync_file_range2 = 84,
+        /// See [sync_file_range(2)](https://man7.org/linux/man-pages/man2/sync_file_range.2.html) for more info on this syscall.
+        sync_file_range = 84,
         /// See [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html) for more info on this syscall.
         timerfd_create = 85,
         /// See [timerfd_settime(2)](https://man7.org/linux/man-pages/man2/timerfd_settime.2.html) for more info on this syscall.

--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -172,8 +172,8 @@ syscall_enum! {
         fsync = 82,
         /// See [fdatasync(2)](https://man7.org/linux/man-pages/man2/fdatasync.2.html) for more info on this syscall.
         fdatasync = 83,
-        /// See [sync_file_range2(2)](https://man7.org/linux/man-pages/man2/sync_file_range2.2.html) for more info on this syscall.
-        sync_file_range2 = 84,
+        /// See [sync_file_range(2)](https://man7.org/linux/man-pages/man2/sync_file_range.2.html) for more info on this syscall.
+        sync_file_range = 84,
         /// See [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html) for more info on this syscall.
         timerfd_create = 85,
         /// See [timerfd_settime(2)](https://man7.org/linux/man-pages/man2/timerfd_settime.2.html) for more info on this syscall.

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -172,8 +172,8 @@ syscall_enum! {
         fsync = 82,
         /// See [fdatasync(2)](https://man7.org/linux/man-pages/man2/fdatasync.2.html) for more info on this syscall.
         fdatasync = 83,
-        /// See [sync_file_range2(2)](https://man7.org/linux/man-pages/man2/sync_file_range2.2.html) for more info on this syscall.
-        sync_file_range2 = 84,
+        /// See [sync_file_range(2)](https://man7.org/linux/man-pages/man2/sync_file_range.2.html) for more info on this syscall.
+        sync_file_range = 84,
         /// See [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html) for more info on this syscall.
         timerfd_create = 85,
         /// See [timerfd_settime(2)](https://man7.org/linux/man-pages/man2/timerfd_settime.2.html) for more info on this syscall.

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -47,10 +47,9 @@ lazy_static! {
                 //"arch/arm64/include/asm/unistd.h",
             ],
             blocklist: &[
-                // This syscall was renamed to `sync_file_range2` on aarch64.
-                // Thus, only `sync_file_range2` should appear in the syscall
-                // table.
-                "sync_file_range",
+                // NOTE: On aarch64 platforms, `sync_file_range2` only provides
+                // compatibility for aarch32.
+                "sync_file_range2",
             ],
         }),
         Source::Table(Table {
@@ -88,14 +87,18 @@ lazy_static! {
             path: "arch/s390/kernel/syscalls/syscall.tbl",
             abi: &[ABI::COMMON, ABI::B64],
         }),
-        // For riscv32 and riscv64, see aarch64's explanation.
         Source::Header(Header {
             arch: "riscv32",
             headers: &[
                 "include/uapi/asm-generic/unistd.h",
                 "arch/riscv/include/uapi/asm/unistd.h",
             ],
-            blocklist: &["sync_file_range"],
+            blocklist: &[
+                // It doesn't have defines `__NR_sync_file_range2` or
+                // `__ARCH_WANT_SYNC_FILE_RANGE2` in
+                // `arch/riscv/include/uapi/asm/unistd.h` header file
+                "sync_file_range2",
+            ],
         }),
         Source::Header(Header {
             arch: "riscv64",
@@ -103,16 +106,21 @@ lazy_static! {
                 "include/uapi/asm-generic/unistd.h",
                 "arch/riscv/include/uapi/asm/unistd.h",
             ],
-            blocklist: &["sync_file_range"],
+            blocklist: &[
+                // For riscv64, see riscv32's explanation.
+                "sync_file_range2",
+            ],
         }),
-        // For loongarch64, see aarch64's explanation.
         Source::Header(Header {
             arch: "loongarch64",
             headers: &[
                 "include/uapi/asm-generic/unistd.h",
                 "arch/loongarch/include/uapi/asm/unistd.h",
             ],
-            blocklist: &["sync_file_range"],
+            blocklist: &[
+                // For loongarch64, see riscv32's explanation.
+                "sync_file_range2",
+            ],
         }),
     ];
 }


### PR DESCRIPTION
This PR will fix `sync_file_range2` corruption in codes.


During these days, I have discovered a bug in `syscall-gen`. It has mistakenly marked some architectures using `sync_file_range2` instead of `sync_file_range`.

Because of registers alignment, on a few architectures, `sync_file_range2` swaps the argument order to avoid requiring 7 arguments instead of `sync_file_range`. After my investigation, only 32-bit ARM[^1], SH[^2], PowerPC[^3], CSKY[^4] and Hexagon[^5] use `sync_file_range2`. Specifically, `arm_sync_file_range` is aliased to `sync_file_range` on 32-bit ARM[^1].

For aarch64, this architectures use `sync_file_range` actually. However, ARMv8 has a compatibility mode called `aarch32`, which will let 32bit ARM programs running on aarch64 machines. So there is a `unistd32.h` syscall compat header in `arch/arm64`[^6]. It also have `sync_file_range2` syscall name, aliased to `arm_sync_file_range`.

For other architectures which use `unistd.h` for syscalls definition, we should filter out `sync_file_range2` if not defined. That follows their definitions in Linux kernel.


[^1]: https://github.com/torvalds/linux/blob/176000734ee2978121fde22a954eb1eabb204329/arch/arm/tools/syscall.tbl#L359
[^2]: https://github.com/torvalds/linux/blob/30766f1105d6d2459c3b9fe34a3e52b637a72950/arch/sh/kernel/syscalls/syscall.tbl#L398
[^3]: https://github.com/torvalds/linux/blob/b1e31c134a8ab2e8f5fd62323b6b45a950ac704d/arch/powerpc/kernel/syscalls/syscall.tbl#L401
[^4]: https://github.com/torvalds/linux/blob/f840cab63efe802638bf536221deecfbf3f569ed/arch/csky/include/uapi/asm/unistd.h#L5
[^5]: https://github.com/torvalds/linux/blob/36d69c29759ec2299c1537e292a466eab3824087/arch/hexagon/include/uapi/asm/unistd.h
[^6]: https://github.com/torvalds/linux/blob/7fe33e9f662c0a2f5110be4afff0a24e0c123540/arch/arm64/include/asm/unistd32.h#L7