### PR TITLE
Add back RISC-V arch-specific syscalls

### DIFF
--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -492,6 +492,10 @@ syscall_enum! {
         accept4 = 242,
         /// See [recvmmsg(2)](https://man7.org/linux/man-pages/man2/recvmmsg.2.html) for more info on this syscall.
         recvmmsg = 243,
+        /// See [riscv_hwprobe(2)](https://man7.org/linux/man-pages/man2/riscv_hwprobe.2.html) for more info on this syscall.
+        riscv_hwprobe = 258,
+        /// See [riscv_flush_icache(2)](https://man7.org/linux/man-pages/man2/riscv_flush_icache.2.html) for more info on this syscall.
+        riscv_flush_icache = 259,
         /// See [wait4(2)](https://man7.org/linux/man-pages/man2/wait4.2.html) for more info on this syscall.
         wait4 = 260,
         /// See [prlimit64(2)](https://man7.org/linux/man-pages/man2/prlimit64.2.html) for more info on this syscall.


### PR DESCRIPTION
See #58 

This is a short-term workaround, but can fix compilation for reverse-dependencies like [lurk](https://github.com/JakWai01/lurk), which currently fails with:

```text
error[E0599]: no variant or associated item named `riscv_hwprobe` found for enum `syscalls::Sysno` in the current scope
   --> /build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lurk-cli-0.3.11/src/arch/riscv64.rs:638:18
    |
351 |         Some((Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, None]))
    |                      ----- due to this macro variable
...
638 |         syscall!(riscv_hwprobe, ADDR, INT, INT, ADDR, INT),
    |                  ^^^^^^^^^^^^^ variant or associated item not found in `syscalls::Sysno`

error[E0599]: no variant or associated item named `riscv_flush_icache` found for enum `syscalls::Sysno` in the current scope
   --> /build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lurk-cli-0.3.11/src/arch/riscv64.rs:639:18
    |
345 |         Some((Sysno::$name, [$arg0, $arg1, $arg2, None, None, None]))
    |                      ----- due to this macro variable
...
639 |         syscall!(riscv_flush_icache, ADDR, ADDR, INT),
    |                  ^^^^^^^^^^^^^^^^^^ variant or associated item not found in `syscalls::Sysno`
```

It would be much appreciated if a new release could be made after merging this, so downstream distros like Arch Linux RISC-V won't need to patch this crate!