### PR TITLE
Update kernel version to v6.19 as to include the new `listns` syscall

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -694,6 +694,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -848,6 +848,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -694,6 +694,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/mips.rs
+++ b/src/arch/mips.rs
@@ -890,6 +890,8 @@ syscall_enum! {
         file_getattr = 4468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 4469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 4470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/mips64.rs
+++ b/src/arch/mips64.rs
@@ -748,6 +748,8 @@ syscall_enum! {
         file_getattr = 5468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 5469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 5470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/powerpc.rs
+++ b/src/arch/powerpc.rs
@@ -904,6 +904,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/powerpc64.rs
+++ b/src/arch/powerpc64.rs
@@ -848,6 +848,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -640,6 +640,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -656,6 +656,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/s390x.rs
+++ b/src/arch/s390x.rs
@@ -780,6 +780,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/sparc.rs
+++ b/src/arch/sparc.rs
@@ -880,6 +880,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/sparc64.rs
+++ b/src/arch/sparc64.rs
@@ -806,6 +806,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -922,6 +922,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -770,6 +770,8 @@ syscall_enum! {
         file_getattr = 468,
         /// See [file_setattr(2)](https://man7.org/linux/man-pages/man2/file_setattr.2.html) for more info on this syscall.
         file_setattr = 469,
+        /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
+        listns = 470,
     }
-    LAST: file_setattr;
+    LAST: listns;
 }

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -17,7 +17,7 @@ mod tables;
 static LINUX_REPO: &str = "https://raw.githubusercontent.com/torvalds/linux";
 
 /// Linux version to pull the syscall tables from.
-static LINUX_VERSION: &str = "v6.18";
+static LINUX_VERSION: &str = "v6.19";
 
 lazy_static! {
     /// List of syscall tables for each architecture.


### PR DESCRIPTION
The v6.19 update introduced the `listns` syscall as described in [this LWN article](https://lwn.net/Articles/1043824/) and [the patch](https://lore.kernel.org/all/20251029-work-namespace-nstree-listns-v4-19-2e6f823ebdc0@kernel.org/). I have tested it on the C side and it works.
There is no man page for the syscall and it's request structure yet though, so the generated man page link returns `404`.