### PR TITLE
Linux v7.0: add `rseq_slice_yield` syscall

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -696,6 +696,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -850,6 +850,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -696,6 +696,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/mips.rs
+++ b/src/arch/mips.rs
@@ -892,6 +892,8 @@ syscall_enum! {
         file_setattr = 4469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 4470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 4471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/mips64.rs
+++ b/src/arch/mips64.rs
@@ -750,6 +750,8 @@ syscall_enum! {
         file_setattr = 5469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 5470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 5471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/powerpc.rs
+++ b/src/arch/powerpc.rs
@@ -906,6 +906,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/powerpc64.rs
+++ b/src/arch/powerpc64.rs
@@ -850,6 +850,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/riscv32.rs
+++ b/src/arch/riscv32.rs
@@ -642,6 +642,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -658,6 +658,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/s390x.rs
+++ b/src/arch/s390x.rs
@@ -782,6 +782,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/sparc.rs
+++ b/src/arch/sparc.rs
@@ -814,6 +814,8 @@ syscall_enum! {
         fspick = 433,
         /// See [pidfd_open(2)](https://man7.org/linux/man-pages/man2/pidfd_open.2.html) for more info on this syscall.
         pidfd_open = 434,
+        /// See [clone3(2)](https://man7.org/linux/man-pages/man2/clone3.2.html) for more info on this syscall.
+        clone3 = 435,
         /// See [close_range(2)](https://man7.org/linux/man-pages/man2/close_range.2.html) for more info on this syscall.
         close_range = 436,
         /// See [openat2(2)](https://man7.org/linux/man-pages/man2/openat2.2.html) for more info on this syscall.
@@ -882,6 +884,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/sparc64.rs
+++ b/src/arch/sparc64.rs
@@ -740,6 +740,8 @@ syscall_enum! {
         fspick = 433,
         /// See [pidfd_open(2)](https://man7.org/linux/man-pages/man2/pidfd_open.2.html) for more info on this syscall.
         pidfd_open = 434,
+        /// See [clone3(2)](https://man7.org/linux/man-pages/man2/clone3.2.html) for more info on this syscall.
+        clone3 = 435,
         /// See [close_range(2)](https://man7.org/linux/man-pages/man2/close_range.2.html) for more info on this syscall.
         close_range = 436,
         /// See [openat2(2)](https://man7.org/linux/man-pages/man2/openat2.2.html) for more info on this syscall.
@@ -808,6 +810,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -924,6 +924,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -772,6 +772,8 @@ syscall_enum! {
         file_setattr = 469,
         /// See [listns(2)](https://man7.org/linux/man-pages/man2/listns.2.html) for more info on this syscall.
         listns = 470,
+        /// See [rseq_slice_yield(2)](https://man7.org/linux/man-pages/man2/rseq_slice_yield.2.html) for more info on this syscall.
+        rseq_slice_yield = 471,
     }
-    LAST: listns;
+    LAST: rseq_slice_yield;
 }

--- a/syscalls-gen/src/main.rs
+++ b/syscalls-gen/src/main.rs
@@ -17,7 +17,7 @@ mod tables;
 static LINUX_REPO: &str = "https://raw.githubusercontent.com/torvalds/linux";
 
 /// Linux version to pull the syscall tables from.
-static LINUX_VERSION: &str = "v6.19";
+static LINUX_VERSION: &str = "v7.0";
 
 lazy_static! {
     /// List of syscall tables for each architecture.


### PR DESCRIPTION
v7.0 added the `rseq_slice_yield` syscall, https://lwn.net/Articles/1038235/.
I'm opening this as a draft because 7.0 is mainline, but isn't stable yet. AFAIK it should be ready in about a week.